### PR TITLE
Port musicutils.py to TypeScript

### DIFF
--- a/src/.prototype/musicutils/ts/musicutils.test.ts
+++ b/src/.prototype/musicutils/ts/musicutils.test.ts
@@ -1,0 +1,144 @@
+import {
+    stripAccidental,
+    normalizePitch,
+    displayPitch,
+    isASharp,
+    findSharpIndex,
+    isAFlat,
+    findFlatIndex,
+    getPitchType
+} from './musicutils';
+
+describe('Music utilities', () => {
+    describe('Validate stripAccidental', () => {
+        test('Strip accidental on pitch gbb and expect pitch g with -2 change in half steps', () => {
+            expect(stripAccidental('gbb')).toEqual(['g', -2]);
+        });
+
+        test('Strip accidental on pitch d𝄫 and expect pitch d with -2 change in half steps', () => {
+            expect(stripAccidental('d𝄫')).toEqual(['d', -2]);
+        });
+
+        test('Strip accidental on pitch c♭ and expect pitch c with -1 change in half steps', () => {
+            expect(stripAccidental('c♭')).toEqual(['c', -1]);
+        });
+
+        test('Strip accidental on pitch a♯ and expect pitch a with +1 change in half steps', () => {
+            expect(stripAccidental('a♯')).toEqual(['a', 1]);
+        });
+
+        test('Strip accidental on pitch b♮ and expect pitch b with 0 change in half steps', () => {
+            expect(stripAccidental('b♮')).toEqual(['b', 0]);
+        });
+    });
+
+    describe('Validate normalizePitch', () => {
+        test('Normalize pitch C♭ and expect to be cb', () => {
+            expect(normalizePitch('C♭')).toBe('cb');
+        });
+
+        test('Normalize pitch C♯ and expect to be c#', () => {
+            expect(normalizePitch('C♯')).toBe('c#');
+        });
+
+        test('Normalize pitch C♮ and expect to be c', () => {
+            expect(normalizePitch('C♮')).toBe('c');
+        });
+
+        test('Normalize pitch C𝄫 and expect to be cbb', () => {
+            expect(normalizePitch('C𝄫')).toBe('cbb');
+        });
+    });
+
+    describe('Validate displayPitch', () => {
+        test('Pretty print cb and expect to be C♭', () => {
+            expect(displayPitch('cb')).toBe('C♭');
+        });
+
+        test('Pretty print d# and expect to be D♯', () => {
+            expect(displayPitch('d#')).toBe('D♯');
+        });
+
+        test('Pretty print dbb and expect to be D𝄫', () => {
+            expect(displayPitch('dbb')).toBe('D𝄫');
+        });
+    });
+
+    describe('Validate isASharp', () => {
+        test('Test c# and expect it to be a sharp pitch', () => {
+            expect(isASharp('c#')).toBe(true);
+        });
+
+        test('Test g and expect it to be a sharp pitch', () => {
+            expect(isASharp('g')).toBe(true);
+        });
+
+        test('Test bb and expect it to not be a sharp pitch', () => {
+            expect(isASharp('bb')).toBe(false);
+        });
+    });
+
+    describe('Validate findSharpIndex', () => {
+        test('Generate index of sharp in pitch d# and expect 3', () => {
+            expect(findSharpIndex('d#')).toEqual(3);
+        });
+
+        test('Generate index of sharp in pitch c# and expect 1', () => {
+            expect(findSharpIndex('c#')).toEqual(1);
+        });
+
+        test('Generate index of sharp in pitch gx and expect 9', () => {
+            expect(findSharpIndex('gx')).toEqual(9);
+        });
+    });
+
+    describe('Validate isAFlat', () => {
+        test('Test bb and expect it to be a flat pitch', () => {
+            expect(isAFlat('bb')).toBe(true);
+        });
+
+        test('Test g and expect it to be a flat pitch', () => {
+            expect(isAFlat('g')).toBe(true);
+        });
+
+        test('Test c# and expect it to not be a flat pitch', () => {
+            expect(isAFlat('c#')).toBe(false);
+        });
+
+        test('Test a# and expect it to not be a flat pitch', () => {
+            expect(isAFlat('a#')).toBe(false);
+        });
+    });
+
+    describe('Validate findFlatIndex', () => {
+        test('Generate index of flat in pitch db and expect 1', () => {
+            expect(findFlatIndex('db')).toBe(1);
+        });
+
+        test('Generate index of sharp in pitch bbb and expect 9', () => {
+            expect(findFlatIndex('bbb')).toBe(9);
+        });
+
+        test('Generate index of sharp in pitch gbb and expect 5', () => {
+            expect(findFlatIndex('gbb')).toBe(5);
+        });
+    });
+
+    describe('Validate getPitchType', () => {
+        test("Generate pitch type of pitch bb and expect 'letter name'", () => {
+            expect(getPitchType('bb')).toBe('letter name');
+        });
+
+        test("Generate pitch type of pitch do and expect 'solfege name'", () => {
+            expect(getPitchType('do')).toBe('solfege name');
+        });
+
+        test("Generate pitch type of pitch dha and expect 'east indian solfege name'", () => {
+            expect(getPitchType('dha')).toBe('east indian solfege name');
+        });
+
+        test("Generate pitch type of pitch aaa and expect 'uknown'", () => {
+            expect(getPitchType('aaa')).toBe('unknown');
+        });
+    });
+});

--- a/src/.prototype/musicutils/ts/musicutils.ts
+++ b/src/.prototype/musicutils/ts/musicutils.ts
@@ -1,0 +1,503 @@
+/*
+ * Utilities and constants retated to musical state as required by other related modules.
+ */
+
+const SHARP: string = '♯';
+const FLAT: string = '♭';
+const NATURAL: string = '♮';
+const DOUBLESHARP: string = '𝄪';
+const DOUBLEFLAT: string = '𝄫';
+
+export const CHROMATIC_NOTES_SHARP: string[] = [
+    'c',
+    'c#',
+    'd',
+    'd#',
+    'e',
+    'f',
+    'f#',
+    'g',
+    'g#',
+    'a',
+    'a#',
+    'b'
+];
+
+export const CHROMATIC_NOTES_FLAT: string[] = [
+    'c',
+    'db',
+    'd',
+    'eb',
+    'e',
+    'f',
+    'gb',
+    'g',
+    'ab',
+    'a',
+    'bb',
+    'b'
+];
+
+/**
+ * @remarks
+ * Meantone temperaments use 21 notes.
+ */
+export const ALL_NOTES: string[] = [
+    'c',
+    'c#',
+    'db',
+    'd',
+    'd#',
+    'eb',
+    'e',
+    'e#',
+    'fb',
+    'f',
+    'f#',
+    'gb',
+    'g',
+    'g#',
+    'ab',
+    'a',
+    'a#',
+    'bb',
+    'b',
+    'b#',
+    'cb'
+];
+
+export const SCALAR_MODE_NUMBERS: string[] = ['1', '2', '3', '4', '5', '6', '7'];
+
+export const SOLFEGE_NAMES: string[] = ['do', 're', 'me', 'fa', 'sol', 'la', 'ti'];
+
+export const EAST_INDIAN_NAMES: string[] = ['sa', 're', 'ga', 'ma', 'pa', 'dha', 'ni'];
+
+export const EQUIVALENT_FLATS: { [key: string]: string } = {
+    'c#': 'db',
+    'd#': 'eb',
+    'f#': 'gb',
+    'g#': 'ab',
+    'a#': 'bb',
+    'e#': 'f',
+    'b#': 'c',
+    'cb': 'cb',
+    'fb': 'fb'
+};
+
+export const EQUIVALENT_SHARPS: { [key: string]: string } = {
+    'db': 'c#',
+    'eb': 'd#',
+    'gb': 'f#',
+    'ab': 'g#',
+    'bb': 'a#',
+    'cb': 'b',
+    'fb': 'e',
+    'e#': 'e#',
+    'b#': 'b#'
+};
+
+/**
+ * @remarks
+ * This notation only applies to temperaments with 12 semitones.
+ */
+export const PITCH_LETTERS: string[] = ['c', 'd', 'e', 'f', 'g', 'a', 'b'];
+
+/**
+ * @remarks
+ * These defintions are only relevant to equal temperament.
+ */
+export const SOLFEGE_SHARP: string[] = [
+    'do',
+    'do#',
+    're',
+    're#',
+    'me',
+    'fa',
+    'fa#',
+    'sol',
+    'sol#',
+    'la',
+    'la#',
+    'ti'
+];
+
+export const SOLFEGE_FLAT: string[] = [
+    'do',
+    'reb',
+    're',
+    'meb',
+    'me',
+    'fa',
+    'solb',
+    'sol',
+    'lab',
+    'la',
+    'tib',
+    'ti'
+];
+
+export const EAST_INDIAN_SHARP: string[] = [
+    'sa',
+    'sa#',
+    're',
+    're#',
+    'ga',
+    'ma',
+    'ma#',
+    'pa',
+    'pa#',
+    'dha',
+    'dha#',
+    'ni'
+];
+
+export const EAST_INDIAN_FLAT: string[] = [
+    'sa',
+    'reb',
+    're',
+    'gab',
+    'ga',
+    'ma',
+    'pab',
+    'pa',
+    'dhab',
+    'dha',
+    'nib',
+    'ni'
+];
+
+export const SCALAR_NAMES_SHARP: string[] = [
+    '1',
+    '1#',
+    '2',
+    '2#',
+    '3',
+    '4',
+    '4#',
+    '5',
+    '5#',
+    '6',
+    '6#',
+    '7'
+];
+
+export const SCALAR_NAMES_FLAT: string[] = [
+    '1',
+    '2b',
+    '2',
+    '3b',
+    '3',
+    '4',
+    '4b',
+    '5',
+    '6b',
+    '6',
+    '7b',
+    '7'
+];
+
+export const EQUIVALENTS: { [key: string]: string[] } = {
+    'ax': ['b', 'cb'],
+    'a#': ['bb'],
+    'a': ['a', 'bbb', 'gx'],
+    'ab': ['g#'],
+    'abb': ['g', 'fx'],
+    'bx': ['c#'],
+    'b#': ['c', 'dbb'],
+    'b': ['b', 'cb', 'ax'],
+    'bb': ['a#'],
+    'bbb': ['a', 'gx'],
+    'cx': ['d'],
+    'c#': ['db'],
+    'c': ['c', 'dbb', 'b#'],
+    'cb': ['b'],
+    'cbb': ['bb', 'a#'],
+    'dx': ['e', 'fb'],
+    'd#': ['eb', 'fbb'],
+    'd': ['d', 'ebb', 'cx'],
+    'db': ['c#', 'bx'],
+    'dbb': ['c', 'b#'],
+    'ex': ['f#', 'gb'],
+    'e#': ['f', 'gbb'],
+    'e': ['e', 'fb', 'dx'],
+    'eb': ['d#', 'fbb'],
+    'ebb': ['d', 'cx'],
+    'fx': ['g', 'abb'],
+    'f#': ['gb', 'ex'],
+    'f': ['f', 'e#', 'gbb'],
+    'fb': ['e', 'dx'],
+    'fbb': ['eb', 'd#'],
+    'gx': ['a', 'bbb'],
+    'g#': ['ab'],
+    'g': ['g', 'abb', 'fx'],
+    'gb': ['f#', 'ex'],
+    'gbb': ['f', 'e#']
+};
+
+export const CONVERT_DOWN: { [key: string]: string } = {
+    c: 'b#',
+    cb: 'b',
+    cbb: 'a#',
+    d: 'cx',
+    db: 'c#',
+    dbb: 'c',
+    e: 'dx',
+    eb: 'd#',
+    ebb: 'd',
+    f: 'e#',
+    fb: 'e',
+    fbb: 'd#',
+    g: 'fx',
+    gb: 'f#',
+    gbb: 'f',
+    a: 'gx',
+    ab: 'g#',
+    abb: 'g',
+    b: 'ax',
+    bb: 'a#',
+    bbb: 'a'
+};
+
+export const CONVERT_UP: { [key: string]: string } = {
+    'cx': 'd',
+    'c#': 'db',
+    'c': 'dbb',
+    'dx': 'e',
+    'd#': 'eb',
+    'd': 'ebb',
+    'ex': 'f#',
+    'e#': 'f',
+    'e': 'fb',
+    'fx': 'g',
+    'f#': 'gb',
+    'f': 'gbb',
+    'gx': 'a',
+    'g#': 'ab',
+    'g': 'abb',
+    'ax': 'b',
+    'a#': 'bb',
+    'a': 'bbb',
+    'bx': 'c#',
+    'b#': 'c',
+    'b': 'cb'
+};
+
+// Pitch name types
+
+export const GENERIC_NOTE_NAME = 'generic note name';
+export const LETTER_NAME = 'letter name';
+export const SOLFEGE_NAME = 'solfege name';
+export const EAST_INDIAN_SOLFEGE_NAME = 'east indian solfege name';
+export const SCALAR_MODE_NUMBER = 'scalar mode number';
+export const CUSTOM_NAME = 'custom name';
+export const UNKNOWN_PITCH_NAME = 'unknown';
+
+/**
+ * Removes an accidental and return the number of half steps that would have resulted from its
+ * application to the pitch.
+ *
+ * @param pitch - Upper or lowecase pitch name with accidentals as ASCII or Unicode.
+ * @returns An array (2-tuple) of the normalized pitch name and the change in half steps represented
+ * by the removed accidental.
+ */
+export function stripAccidental(pitch: string): [string, number] {
+    if (pitch.length === 1) {
+        return [pitch, 0];
+    }
+
+    // The ASCII versions.
+    if (pitch.length > 2 && pitch.endsWith('bb')) {
+        return [pitch.slice(0, pitch.length - 2), -2];
+    }
+    if (pitch.endsWith('b')) {
+        return [pitch.slice(0, pitch.length - 1), -1];
+    }
+    if (pitch.endsWith('#')) {
+        return [pitch.slice(0, pitch.length - 1), 1];
+    }
+    if (pitch.endsWith('x')) {
+        return [pitch.slice(0, pitch.length - 1), 2];
+    }
+
+    // And the Unicode versions...
+    if (pitch.endsWith(DOUBLEFLAT)) {
+        return [pitch.slice(0, pitch.length - 2), -2];
+    }
+    if (pitch.endsWith(FLAT)) {
+        return [pitch.slice(0, pitch.length - 1), -1];
+    }
+    if (pitch.endsWith(SHARP)) {
+        return [pitch.slice(0, pitch.length - 1), 1];
+    }
+    if (pitch.endsWith(DOUBLESHARP)) {
+        return [pitch.slice(0, pitch.length - 1), 2];
+    }
+    if (pitch.endsWith(NATURAL)) {
+        return [pitch.slice(0, pitch.length - 1), 0];
+    }
+
+    // No accidentals were present.
+    return [pitch, 0];
+}
+
+/**
+ * Returns the normalized pitch nane.
+ *
+ * @remarks
+ * Internally, we use a standardize form for our pitch letter names:
+ * - Lowercase c, d, e, f, g, a, b for letter names.
+ * - #, b, x, and bb for sharp, flat, double sharp, and double flat for accidentals.
+ *
+ * Note names for temperaments with more than 12 semitones are of the form: n0, n1, ...
+ *
+ * @param pitch - Upper or lowecase pitch name with accidentals as ASCII or Unicode.
+ */
+export function normalizePitch(pitch: string): string {
+    if (typeof pitch === 'number') {
+        return pitch;
+    }
+
+    pitch = pitch.toLowerCase();
+    pitch = pitch.replace(SHARP, '#');
+    pitch = pitch.replace(DOUBLESHARP, 'x');
+    pitch = pitch.replace(FLAT, 'b');
+    pitch = pitch.replace(DOUBLEFLAT, 'bb');
+    pitch = pitch.replace(NATURAL, '');
+    return pitch;
+}
+
+/**
+ * Returns a pretty pitch name.
+ *
+ * @remarks
+ * The internal pitch name is converted to unicode, e.g., cb --> C♭.
+ *
+ * @param pitch - Upper or lowecase pitch name with accidentals as ASCII or Unicode.
+ */
+export function displayPitch(pitch: string): string {
+    // Ignore pitch numbers and pitch expressed as Hertz.
+    if (typeof pitch === 'number') {
+        return pitch;
+    }
+
+    let pitchToDisplay: string = pitch[0].toUpperCase();
+    if (pitch.length > 2 && pitch.slice(1, 3) === 'bb') {
+        pitchToDisplay += DOUBLEFLAT;
+    } else if (pitch.length > 1) {
+        if (pitch[1] === '#') {
+            pitchToDisplay += SHARP;
+        } else if (pitch[1].toLowerCase() === 'x') {
+            pitchToDisplay += DOUBLESHARP;
+        } else if (pitch[1].toLowerCase() === 'b') {
+            pitchToDisplay += FLAT;
+        }
+    }
+    return pitchToDisplay;
+}
+
+/**
+ * Returns whether the pitch is a sharp or not flat?
+ *
+ * @param pitchName - The pitch name to test.
+ */
+export function isASharp(pitchName: string): boolean {
+    return pitchName.endsWith('#') || PITCH_LETTERS.includes(pitchName);
+}
+
+/**
+ * Returns the index value of the pitch name.
+ *
+ * @param pitchName - The pitch name to test.
+ * @returns Index into the chromatic scale with sharp notes.
+ *
+ * @throws {ItemNotFoundError}
+ * Thrown if pitchName isn't in chromatic scale.
+ */
+export function findSharpIndex(pitchName: string): number {
+    if (CHROMATIC_NOTES_SHARP.includes(pitchName)) {
+        return CHROMATIC_NOTES_SHARP.indexOf(pitchName);
+    }
+
+    if (CONVERT_UP.hasOwnProperty(pitchName)) {
+        const newPitchName = CONVERT_UP[pitchName];
+        if (CHROMATIC_NOTES_SHARP.includes(newPitchName)) {
+            return CHROMATIC_NOTES_SHARP.indexOf(newPitchName);
+        }
+    }
+
+    throw Error(`ItemNotFoundError: Could not find sharp index for ${pitchName}`);
+}
+
+/**
+ * Returns whether the pitch is a flat or not sharp?
+ *
+ * @param pitchName - The pitch name to test.
+ */
+export function isAFlat(pitchName: string): boolean {
+    return pitchName.endsWith('b') || PITCH_LETTERS.includes(pitchName);
+}
+
+/**
+ * Returns the index value of the pitch name.
+ *
+ * @param pitchName - The pitch name to test.
+ * @returns Index into the chromatic scale with sharp notes.
+ *
+ * @throws {ItemNotFoundError}
+ * Thrown if pitchName isn't in chromatic scale.
+ */
+export function findFlatIndex(pitchName: string): number {
+    if (CHROMATIC_NOTES_FLAT.includes(pitchName)) {
+        return CHROMATIC_NOTES_FLAT.indexOf(pitchName);
+    }
+
+    if (CONVERT_DOWN.hasOwnProperty(pitchName)) {
+        const newPitchName = CONVERT_DOWN[pitchName];
+        if (CHROMATIC_NOTES_FLAT.includes(newPitchName)) {
+            return CHROMATIC_NOTES_FLAT.indexOf(newPitchName);
+        }
+    }
+
+    throw Error(`ItemNotFoundError: Could not find flat index for ${pitchName}`);
+}
+
+/**
+ * @remarks
+ * Pitches can be specified as a letter name, a solfege name, etc.
+ *
+ * @param pitchName - The pitch name to test.
+ * @returns The type of the pitch (letter name, solfege name, generic note name,or east indian
+ * solfege name).
+ */
+export function getPitchType(pitchName: string): string {
+    pitchName = normalizePitch(pitchName);
+
+    if (CHROMATIC_NOTES_SHARP.includes(pitchName)) {
+        return LETTER_NAME;
+    }
+    if (CHROMATIC_NOTES_FLAT.includes(pitchName)) {
+        return LETTER_NAME;
+    }
+    if (EQUIVALENT_SHARPS.hasOwnProperty(pitchName)) {
+        return LETTER_NAME;
+    }
+    if (EQUIVALENT_FLATS.hasOwnProperty(pitchName)) {
+        return LETTER_NAME;
+    }
+
+    pitchName = stripAccidental(pitchName)[0];
+
+    if (pitchName[0] === 'n' && Number(pitchName.slice(1)) % 1 !== 0) {
+        return GENERIC_NOTE_NAME;
+    }
+    if (SOLFEGE_NAMES.includes(pitchName)) {
+        return SOLFEGE_NAME;
+    }
+    if (EAST_INDIAN_NAMES.includes(pitchName)) {
+        return EAST_INDIAN_SOLFEGE_NAME;
+    }
+    if (SCALAR_MODE_NUMBERS.includes(pitchName)) {
+        return SCALAR_MODE_NUMBER;
+    }
+    return UNKNOWN_PITCH_NAME;
+}


### PR DESCRIPTION
Addresses #18.

Modified from #27. Reworked on the commits by cherry picking and interactive rebasing.

- Port contents of `musicutils.py` to `musicutils.ts`
- Add unit tests in `musicutils.test.ts` re utility functions in `musicutils.ts`

**Test verification:**
![Screenshot 2021-03-20 at 6 07 33 PM](https://user-images.githubusercontent.com/33328728/111870042-4af4cb80-89a8-11eb-8b8e-440b2d739f11.png)

**Todo:**

- Add missing error test cases