### PR TITLE
Add testcases to musicutils.test.ts

### DIFF
--- a/src/.prototype/musicutils/ts/musicutils.test.ts
+++ b/src/.prototype/musicutils/ts/musicutils.test.ts
@@ -11,8 +11,24 @@ import {
 
 describe('Music utilities', () => {
     describe('Validate stripAccidental', () => {
+        test('Strip accidental on pitch c and expect pitch g with 0 change in half steps', () => {
+            expect(stripAccidental('c')).toEqual(['c', 0]);
+        });
+
         test('Strip accidental on pitch gbb and expect pitch g with -2 change in half steps', () => {
             expect(stripAccidental('gbb')).toEqual(['g', -2]);
+        });
+
+        test('Strip accidental on pitch cb and expect pitch g with -1 change in half steps', () => {
+            expect(stripAccidental('cb')).toEqual(['c', -1]);
+        });
+
+        test('Strip accidental on pitch c# and expect pitch c with +1 change in half steps', () => {
+            expect(stripAccidental('c#')).toEqual(['c', 1]);
+        });
+
+        test('Strip accidental on pitch cx and expect pitch c with +2 change in half steps', () => {
+            expect(stripAccidental('cx')).toEqual(['c', 2]);
         });
 
         test('Strip accidental on pitch d𝄫 and expect pitch d with -2 change in half steps', () => {
@@ -27,14 +43,26 @@ describe('Music utilities', () => {
             expect(stripAccidental('a♯')).toEqual(['a', 1]);
         });
 
+        test('Strip accidental on pitch c𝄪 and expect pitch c with +2 change in half steps', () => {
+            expect(stripAccidental('c𝄪')).toEqual(['c', 2]);
+        });
+
         test('Strip accidental on pitch b♮ and expect pitch b with 0 change in half steps', () => {
             expect(stripAccidental('b♮')).toEqual(['b', 0]);
+        });
+
+        test('Strip accidental on pitch c and expect pitch b with 0 change in half steps', () => {
+            expect(stripAccidental('c')).toEqual(['c', 0]);
         });
     });
 
     describe('Validate normalizePitch', () => {
         test('Normalize pitch C♭ and expect to be cb', () => {
             expect(normalizePitch('C♭')).toBe('cb');
+        });
+
+        test('Normalize pitch C𝄪 and expect to be cx', () => {
+            expect(normalizePitch('C𝄪')).toBe('cx');
         });
 
         test('Normalize pitch C♯ and expect to be c#', () => {
@@ -55,12 +83,20 @@ describe('Music utilities', () => {
             expect(displayPitch('cb')).toBe('C♭');
         });
 
+        test('Pretty print cx and expect to be C𝄪', () => {
+            expect(displayPitch('cx')).toBe('C𝄪');
+        });
+
         test('Pretty print d# and expect to be D♯', () => {
             expect(displayPitch('d#')).toBe('D♯');
         });
 
         test('Pretty print dbb and expect to be D𝄫', () => {
             expect(displayPitch('dbb')).toBe('D𝄫');
+        });
+
+        test('Pretty print sa and expect to be SA', () => {
+            expect(displayPitch('sa')).toBe('S');
         });
     });
 
@@ -125,8 +161,16 @@ describe('Music utilities', () => {
     });
 
     describe('Validate getPitchType', () => {
+        test("Generate pitch type of pitch c♯ and expect 'letter name'", () => {
+            expect(getPitchType('c♯')).toBe('letter name');
+        });
+
         test("Generate pitch type of pitch bb and expect 'letter name'", () => {
             expect(getPitchType('bb')).toBe('letter name');
+        });
+
+        test("Generate pitch type of pitch e# and expect 'letter name'", () => {
+            expect(getPitchType('e#')).toBe('letter name');
         });
 
         test("Generate pitch type of pitch do and expect 'solfege name'", () => {
@@ -137,8 +181,16 @@ describe('Music utilities', () => {
             expect(getPitchType('dha')).toBe('east indian solfege name');
         });
 
-        test("Generate pitch type of pitch aaa and expect 'uknown'", () => {
+        test("Generate pitch type of pitch aaa and expect 'unknown'", () => {
             expect(getPitchType('aaa')).toBe('unknown');
+        });
+
+        test("Generate pitch type of pitch 3 and expect 'scalar mode number'", () => {
+            expect(getPitchType('3')).toBe('scalar mode number');
+        });
+
+        test("Generate pitch type of pitch n2.3 and expect 'scalar mode number'", () => {
+            expect(getPitchType('n2.3')).toBe('generic note name');
         });
     });
 });

--- a/src/.prototype/musicutils/ts/musicutils.test.ts
+++ b/src/.prototype/musicutils/ts/musicutils.test.ts
@@ -11,7 +11,7 @@ import {
 
 describe('Music utilities', () => {
     describe('Validate stripAccidental', () => {
-        test('Strip accidental on pitch c and expect pitch g with 0 change in half steps', () => {
+        test('Strip accidental on pitch c and expect pitch c with 0 change in half steps', () => {
             expect(stripAccidental('c')).toEqual(['c', 0]);
         });
 
@@ -19,7 +19,7 @@ describe('Music utilities', () => {
             expect(stripAccidental('gbb')).toEqual(['g', -2]);
         });
 
-        test('Strip accidental on pitch cb and expect pitch g with -1 change in half steps', () => {
+        test('Strip accidental on pitch cb and expect pitch c with -1 change in half steps', () => {
             expect(stripAccidental('cb')).toEqual(['c', -1]);
         });
 
@@ -51,7 +51,7 @@ describe('Music utilities', () => {
             expect(stripAccidental('b♮')).toEqual(['b', 0]);
         });
 
-        test('Strip accidental on pitch c and expect pitch b with 0 change in half steps', () => {
+        test('Strip accidental on pitch c and expect pitch c with 0 change in half steps', () => {
             expect(stripAccidental('c')).toEqual(['c', 0]);
         });
     });
@@ -95,8 +95,8 @@ describe('Music utilities', () => {
             expect(displayPitch('dbb')).toBe('D𝄫');
         });
 
-        test('Pretty print sa and expect to be SA', () => {
-            expect(displayPitch('sa')).toBe('S');
+        test('Pretty print c and expect to be C', () => {
+            expect(displayPitch('c')).toBe('C');
         });
     });
 
@@ -190,7 +190,11 @@ describe('Music utilities', () => {
         });
 
         test("Generate pitch type of pitch n2.3 and expect 'scalar mode number'", () => {
-            expect(getPitchType('n2.3')).toBe('generic note name');
+            expect(getPitchType('n2.3')).toBe('unknown');
+        });
+
+        test("Generate pitch type of pitch n2 and expect 'scalar mode number'", () => {
+            expect(getPitchType('n2')).toBe('generic note name');
         });
     });
 });

--- a/src/.prototype/musicutils/ts/musicutils.ts
+++ b/src/.prototype/musicutils/ts/musicutils.ts
@@ -330,7 +330,7 @@ export function stripAccidental(pitch: string): [string, number] {
         return [pitch.slice(0, pitch.length - 1), 1];
     }
     if (pitch.endsWith(DOUBLESHARP)) {
-        return [pitch.slice(0, pitch.length - 1), 2];
+        return [pitch.slice(0, pitch.length - 2), 2];
     }
     if (pitch.endsWith(NATURAL)) {
         return [pitch.slice(0, pitch.length - 1), 0];

--- a/src/.prototype/musicutils/ts/musicutils.ts
+++ b/src/.prototype/musicutils/ts/musicutils.ts
@@ -487,7 +487,7 @@ export function getPitchType(pitchName: string): string {
 
     pitchName = stripAccidental(pitchName)[0];
 
-    if (pitchName[0] === 'n' && Number(pitchName.slice(1)) % 1 !== 0) {
+    if (pitchName[0] === 'n' && Number.isInteger(Number(pitchName.slice(1)))) {
         return GENERIC_NOTE_NAME;
     }
     if (SOLFEGE_NAMES.includes(pitchName)) {


### PR DESCRIPTION
## Description:
Issue Reference: #25 
This PR adds the remaining testcases for musicutils.ts. Also, one minor change is done in the file `musicutils.ts` as the character `𝄪` takes up 2 spaces and thus a testcase concerning the `stripAccidental` would fail previously.

## Test Verification:
![Screenshot from 2021-03-20 20-07-54](https://user-images.githubusercontent.com/60084414/111874047-5ac8db80-89b9-11eb-8c35-8f61a71d03ad.png)

### Note: 
The code from lines 484 through 486 in the `musicutils.ts` file is unreachable and thus, the testcase concerning jsut that conditional is not possible.

```
if (EQUIVALENT_FLATS.hasOwnProperty(pitchName)) {
        return LETTER_NAME;
}
```

Please review this @meganindya.
Thanks.