### PR TITLE
Add error testcases to musicutils.test.ts

### DIFF
--- a/src/.prototype/musicutils/ts/musicUtils.test.ts
+++ b/src/.prototype/musicutils/ts/musicUtils.test.ts
@@ -133,6 +133,12 @@ describe('Music utilities', () => {
         test('Generate index of sharp in pitch gx and expect 9', () => {
             expect(findSharpIndex('gx')).toEqual(9);
         });
+
+        test('Generate index of sharp in pitch db and expect a could not find sharp index error', () => {
+            expect(() => {
+                findSharpIndex('db');
+            }).toThrow(new Error('ItemNotFoundError: Could not find sharp index for db'));
+        });
     });
 
     describe('Validate isAFlat', () => {
@@ -164,6 +170,12 @@ describe('Music utilities', () => {
 
         test('Generate index of sharp in pitch gbb and expect 5', () => {
             expect(findFlatIndex('gbb')).toBe(5);
+        });
+
+        test('Generate index of sharp in pitch c# and expect a could not find flat index error', () => {
+            expect(() => {
+                findFlatIndex('c#');
+            }).toThrow(new Error('ItemNotFoundError: Could not find flat index for c#'));
         });
     });
 

--- a/src/.prototype/musicutils/ts/musicUtils.test.ts
+++ b/src/.prototype/musicutils/ts/musicUtils.test.ts
@@ -137,7 +137,7 @@ describe('Music utilities', () => {
         test('Generate index of sharp in pitch db and expect a could not find sharp index error', () => {
             expect(() => {
                 findSharpIndex('db');
-            }).toThrow(new Error('ItemNotFoundError: Could not find sharp index for db'));
+            }).toThrowError('ItemNotFoundError: Could not find sharp index for db');
         });
     });
 
@@ -175,7 +175,7 @@ describe('Music utilities', () => {
         test('Generate index of sharp in pitch c# and expect a could not find flat index error', () => {
             expect(() => {
                 findFlatIndex('c#');
-            }).toThrow(new Error('ItemNotFoundError: Could not find flat index for c#'));
+            }).toThrowError('ItemNotFoundError: Could not find flat index for c#');
         });
     });
 


### PR DESCRIPTION
## Description:
Issue Reference: #25 
This PR adds the remaining testcases covering the error cases of `findSharpIndex` and `findFlatIndex` methods.

## Test Verification
![Screenshot from 2021-03-27 22-19-02](https://user-images.githubusercontent.com/60084414/112728314-9a10a280-8f4c-11eb-9c08-51338277f0cf.png)

Please review this @meganindya.
Thanks.