### PR TITLE
Reorganization

### DIFF
--- a/src/musicUtils/.archive/README.md
+++ b/src/musicUtils/.archive/README.md
@@ -221,7 +221,7 @@ class Temperament:
     temperaments are based on ratios.
     """
 
-    def __init__(self, name="equal"):
+    def __init__(self, name="equal", octave_ratio=2):
         """
         Initialize the class. A temperament will be generated but it can
         subsequently be overriden.
@@ -231,6 +231,21 @@ class Temperament:
 
         name : str
             The name of a temperament, e.g., "equal", "just intonation". etc.
+
+	octave_ratio : float
+	    The ratio between octaves (2 by default)
+        """
+
+    def set_octave_ratio(self, octave_ratio):
+        """
+        The octave ratio is used to determine the size of an octave. By
+        default, it is 2:1, so going up by one octave will double the
+        frequency. But this can be overriden.
+
+        Parameters
+        ----------
+        octave_ratio : float
+        The ratio between octaves
         """
 
     def tune(self, pitch_name, octave, frequency):

--- a/src/musicUtils/.archive/README.md
+++ b/src/musicUtils/.archive/README.md
@@ -232,8 +232,8 @@ class Temperament:
         name : str
             The name of a temperament, e.g., "equal", "just intonation". etc.
 
-	octave_ratio : float
-	    The ratio between octaves (2 by default)
+        octave_ratio : float
+            The ratio between octaves (2 by default)
         """
 
     def set_octave_ratio(self, octave_ratio):

--- a/src/musicUtils/.archive/README.md
+++ b/src/musicUtils/.archive/README.md
@@ -738,6 +738,16 @@ class KeySignature:
 
     def get_scale(self):
         """
+        The scale defined by the key signature.
+
+        Returns
+        -------
+        obj
+            The scale object
+        """
+
+    def get_notes_in_scale(self):
+        """
         The (scalar) notes in the scale.
 
         Returns
@@ -745,7 +755,8 @@ class KeySignature:
         list
             The (scalar) notes in the scale.
 
-        NOTE: The internal definition of the scale includes the octave.
+        NOTE: The internal definition of the notes in a scale includes
+        the octave.
         """
 
     def get_mode_length(self):
@@ -793,29 +804,6 @@ by the key and mode at the time of instanciation.
     scale = ks.get_scale()
 ```
 
-Key Signature supports a variety of naming schemes, including the
-generic note names used by the Temperament object, letter names, both
-fixed and moveable Solfege, East Indian Solfege, scale degree, and
-custom defined names (The pitch name types are defined in
-musicutils.py).
-
-```python
-    ks.set_custom_note_names(
-        ["charlie", "delta", "echo", "foxtrot", "golf", "alfa", "bravo"]
-    )
-
-    generic_name = ks.convert_to_generic_note_name("g")
-    generic_name = ks.convert_to_generic_note_name("sol")
-    generic_name = ks.convert_to_generic_note_name("5")
-    generic_name = ks.convert_to_generic_note_name("pa")
-    generic_name = ks.convert_to_generic_note_name("golf")
-
-    letter_name = ks.generic_note_name_convert_to_type("n7", LETTER_NAME)  # "g"
-    solfege_name = ks.generic_note_name_convert_to_type("n7", SOLFEGE_NAME)  # "sol"
-    ei_solfege_name = ks.generic_note_name_convert_to_type("n7", EAST_INDIAN_SOLFEGE_NAME)  # "pa"
-    custom_name = ks.generic_note_name_convert_to_type("n7", CUSTOM_NAME)  # "golf"
-    scalar_mode_number = ks.generic_note_name_convert_to_type("n7", SCALAR_MODE_NUMBER)  # "5"
-```
 
 Fixed Solfege means that the mapping between Solfege and letter names
 is fixed: do == c, re == d, ...
@@ -825,21 +813,10 @@ scale, etc.
 
 ```python
     ks = KeySignature(key="g", mode="major")
-    generic_name = ks.convert_to_generic_note_name("sol")[0]  # "n7"
+    s = ks.get_scale()
+    generic_name = s.convert_to_generic_note_name("sol")[0]  # "n7"
     ks.set_fixed_solfege(False)  # Moveable
-    generic_name = ks.convert_to_generic_note_name("do")[0]  # "n7"
-```
-
-The Key Signature is used to navigate the scale, either by scalar or
-semitone steps.
-
-```python
-    generic_name, delta_octave, error = ks.semitone_transform(
-        generic_name, number_of_half_steps
-    )
-    generic_name, delta_octave, error = ks.scalar_transform(
-        generic_name, number_of_scalar_steps
-    )
+    generic_name = s.convert_to_generic_note_name("do")[0]  # "n7"
 ```
 
 Scale
@@ -1212,6 +1189,42 @@ object directly, there are public methods available for accessing the
 notes in a scale as an array, the number of notes in the scale, and
 the octave offsets associated with a scale (new octaves always start
 at C regardless of the temperament, key, or mode.
+
+Ths Scale object supports a variety of naming schemes, including the
+generic note names used by the Temperament object, letter names, both
+fixed and moveable Solfege, East Indian Solfege, scale degree, and
+custom defined names (The pitch name types are defined in
+musicutils.py).
+
+```python
+    s.set_custom_note_names(
+        ["charlie", "delta", "echo", "foxtrot", "golf", "alfa", "bravo"]
+    )
+
+    generic_name = s.convert_to_generic_note_name("g")
+    generic_name = s.convert_to_generic_note_name("sol")
+    generic_name = s.convert_to_generic_note_name("5")
+    generic_name = s.convert_to_generic_note_name("pa")
+    generic_name = s.convert_to_generic_note_name("golf")
+
+    letter_name = s.generic_note_name_convert_to_type("n7", LETTER_NAME)  # "g"
+    solfege_name = s.generic_note_name_convert_to_type("n7", SOLFEGE_NAME)  # "sol"
+    ei_solfege_name = s.generic_note_name_convert_to_type("n7", EAST_INDIAN_SOLFEGE_NAME)  # "pa"
+    custom_name = s.generic_note_name_convert_to_type("n7", CUSTOM_NAME)  # "golf"
+    scalar_mode_number = s.generic_note_name_convert_to_type("n7", SCALAR_MODE_NUMBER)  # "5"
+```
+
+The Scale obj is used to navigate the scale, either by scalar or
+semitone steps.
+
+```python
+    generic_name, delta_octave, error = s.semitone_transform(
+        generic_name, number_of_half_steps
+    )
+    generic_name, delta_octave, error = s.scalar_transform(
+        generic_name, number_of_scalar_steps
+    )
+```
 
 Music Utils
 -----------

--- a/src/musicUtils/.archive/README.md
+++ b/src/musicUtils/.archive/README.md
@@ -736,22 +736,6 @@ class KeySignature:
             State of fixed Solfege
         """
 
-    def normalize_scale(self, scale):
-        """
-        Normalize the scale by converting double sharps and double flats.
-
-        Parameters
-        ----------
-        scale : list
-            The notes in a scale
-
-        Returns
-        -------
-        list
-            The same scale where the notes have been converted to just
-            sharps, flats, and naturals
-        """
-
     def get_scale(self):
         """
         The (scalar) notes in the scale.
@@ -784,6 +768,180 @@ class KeySignature:
         int
             The number of semitones in the temperament used to define
             the scale
+        """
+```
+
+Key Signatures are defined by a key and a mode, e.g. `C Major`. This is used
+to define which semitones (half steps) in an octave are in the scale.
+
+```python
+    ks = KeySignature(mode="major", key="c")
+```
+
+By default, the Key Signature object assumes that there are 12
+semitones per octave, but this can be overriden for temperaments with
+other configurations, e.g. the meantone temperaments.
+
+```python
+    ks = KeySignature(mode="major", key="c", number_of_semitones=12)
+```
+
+Within each Key Signature object is a Scale object, which is defined
+by the key and mode at the time of instanciation.
+
+```python
+    scale = ks.get_scale()
+```
+
+Key Signature supports a variety of naming schemes, including the
+generic note names used by the Temperament object, letter names, both
+fixed and moveable Solfege, East Indian Solfege, scale degree, and
+custom defined names (The pitch name types are defined in
+musicutils.py).
+
+```python
+    ks.set_custom_note_names(
+        ["charlie", "delta", "echo", "foxtrot", "golf", "alfa", "bravo"]
+    )
+
+    generic_name = ks.convert_to_generic_note_name("g")
+    generic_name = ks.convert_to_generic_note_name("sol")
+    generic_name = ks.convert_to_generic_note_name("5")
+    generic_name = ks.convert_to_generic_note_name("pa")
+    generic_name = ks.convert_to_generic_note_name("golf")
+
+    letter_name = ks.generic_note_name_convert_to_type("n7", LETTER_NAME)  # "g"
+    solfege_name = ks.generic_note_name_convert_to_type("n7", SOLFEGE_NAME)  # "sol"
+    ei_solfege_name = ks.generic_note_name_convert_to_type("n7", EAST_INDIAN_SOLFEGE_NAME)  # "pa"
+    custom_name = ks.generic_note_name_convert_to_type("n7", CUSTOM_NAME)  # "golf"
+    scalar_mode_number = ks.generic_note_name_convert_to_type("n7", SCALAR_MODE_NUMBER)  # "5"
+```
+
+Fixed Solfege means that the mapping between Solfege and letter names
+is fixed: do == c, re == d, ...
+
+Moveable (not fixed) Solfege means that do == the first note in the
+scale, etc.
+
+```python
+    ks = KeySignature(key="g", mode="major")
+    generic_name = ks.convert_to_generic_note_name("sol")[0]  # "n7"
+    ks.set_fixed_solfege(False)  # Moveable
+    generic_name = ks.convert_to_generic_note_name("do")[0]  # "n7"
+```
+
+The Key Signature is used to navigate the scale, either by scalar or
+semitone steps.
+
+```python
+    generic_name, delta_octave, error = ks.semitone_transform(
+        generic_name, number_of_half_steps
+    )
+    generic_name, delta_octave, error = ks.scalar_transform(
+        generic_name, number_of_scalar_steps
+    )
+```
+
+Scale
+-----
+
+```python
+class Scale:
+    """
+    A scale is a selection of notes in an octave.
+    """
+
+    def __init__(
+        self,
+        half_steps_pattern=None,
+        starting_index=0,
+        number_of_semitones=12,
+        prefer_sharps=True,
+    ):
+        """
+        When defining a scale, we need the half steps pattern that defines
+        the selection anf a starting note, e.g., C or F#,
+
+        Parameters
+        ----------
+        half_steps_pattern : list
+            A list of int values that define how many half steps to take
+            between each note in the scale, e.g., [2, 2, 1, 2, 2, 2, 1]
+            defines the steps for a Major scale
+
+        starting_index : int
+            An index into the half steps defining an octave that determines
+            from where to start building the scale, e.g., 0 for C and 7 for G
+            in a 12-step temperament
+
+        number_of_semitones : int
+            If the half_steps_pattern is an empty list, then use the number
+            of semitones instead. (Or trigger a mapping from 12 to 21.)
+
+        prefer_sharps : boolean
+            If we are mapping from 12 to 21 semitones, we need to know
+            whether or not to prefer sharps or flats.
+        """
+
+    def get_number_of_semitones(self):
+        """
+        The number of semitones is the number of notes in the temperament.
+
+        Returns
+        -------
+        int
+            The number of notes in the scale
+        """
+
+    def get_note_names(self):
+        """
+        The notes defined by the temperament are used to build the scale.
+
+        Returns
+        -------
+        list
+            The notes defined by the temperament
+        """
+
+    def get_scale(self, pitch_format=None):
+        """
+        The notes in the scale are a subset of the notes defined by the
+        temperament.
+
+        Returns
+        -------
+        list
+            The notes in the scale
+        """
+
+    def get_scale_and_octave_deltas(self, pitch_format=None):
+        """
+        The notes in the scale are a subset of the notes defined by the
+        temperament.
+
+        Returns
+        -------
+        list
+            The notes in the scale
+        list
+        The octave deltas (either 0 or 1) are used to mark notes above
+        B#, which would be in the next octave, e.g., G3, A3, B3, C4...
+        """
+
+    def normalize_scale(self, scale):
+        """
+        Normalize the scale by converting double sharps and double flats.
+
+        Parameters
+        ----------
+        scale : list
+            The notes in a scale
+
+        Returns
+        -------
+        list
+            The same scale where the notes have been converted to just
+            sharps, flats, and naturals
         """
 
     def set_custom_note_names(self, custom_names):
@@ -1045,164 +1203,6 @@ class KeySignature:
             target matches a scale pitch, then distance = 0.)
         int
             error code (0 means success)
-        """
-```
-
-Key Signatures are defined by a key and a mode, e.g. `C Major`. This is used
-to define which semitones (half steps) in an octave are in the scale.
-
-```python
-    ks = KeySignature(mode="major", key="c")
-```
-
-By default, the Key Signature object assumes that there are 12
-semitones per octave, but this can be overriden for temperaments with
-other configurations, e.g. the meantone temperaments.
-
-```python
-    ks = KeySignature(mode="major", key="c", number_of_semitones=12)
-```
-
-Within each Key Signature object is a Scale object, which is defined
-by the key and mode at the time of instanciation.
-
-```python
-    scale = ks.get_scale()
-```
-
-Key Signature supports a variety of naming schemes, including the
-generic note names used by the Temperament object, letter names, both
-fixed and moveable Solfege, East Indian Solfege, scale degree, and
-custom defined names (The pitch name types are defined in
-musicutils.py).
-
-```python
-    ks.set_custom_note_names(
-        ["charlie", "delta", "echo", "foxtrot", "golf", "alfa", "bravo"]
-    )
-
-    generic_name = ks.convert_to_generic_note_name("g")
-    generic_name = ks.convert_to_generic_note_name("sol")
-    generic_name = ks.convert_to_generic_note_name("5")
-    generic_name = ks.convert_to_generic_note_name("pa")
-    generic_name = ks.convert_to_generic_note_name("golf")
-
-    letter_name = ks.generic_note_name_convert_to_type("n7", LETTER_NAME)  # "g"
-    solfege_name = ks.generic_note_name_convert_to_type("n7", SOLFEGE_NAME)  # "sol"
-    ei_solfege_name = ks.generic_note_name_convert_to_type("n7", EAST_INDIAN_SOLFEGE_NAME)  # "pa"
-    custom_name = ks.generic_note_name_convert_to_type("n7", CUSTOM_NAME)  # "golf"
-    scalar_mode_number = ks.generic_note_name_convert_to_type("n7", SCALAR_MODE_NUMBER)  # "5"
-```
-
-Fixed Solfege means that the mapping between Solfege and letter names
-is fixed: do == c, re == d, ...
-
-Moveable (not fixed) Solfege means that do == the first note in the
-scale, etc.
-
-```python
-    ks = KeySignature(key="g", mode="major")
-    generic_name = ks.convert_to_generic_note_name("sol")[0]  # "n7"
-    ks.set_fixed_solfege(False)  # Moveable
-    generic_name = ks.convert_to_generic_note_name("do")[0]  # "n7"
-```
-
-The Key Signature is used to navigate the scale, either by scalar or
-semitone steps.
-
-```python
-    generic_name, delta_octave, error = ks.semitone_transform(
-        generic_name, number_of_half_steps
-    )
-    generic_name, delta_octave, error = ks.scalar_transform(
-        generic_name, number_of_scalar_steps
-    )
-```
-
-Scale
------
-
-```python
-class Scale:
-    """
-    A scale is a selection of notes in an octave.
-    """
-
-    def __init__(
-        self,
-        half_steps_pattern=None,
-        starting_index=0,
-        number_of_semitones=12,
-        prefer_sharps=True,
-    ):
-        """
-        When defining a scale, we need the half steps pattern that defines
-        the selection anf a starting note, e.g., C or F#,
-
-        Parameters
-        ----------
-        half_steps_pattern : list
-            A list of int values that define how many half steps to take
-            between each note in the scale, e.g., [2, 2, 1, 2, 2, 2, 1]
-            defines the steps for a Major scale
-
-        starting_index : int
-            An index into the half steps defining an octave that determines
-            from where to start building the scale, e.g., 0 for C and 7 for G
-            in a 12-step temperament
-
-        number_of_semitones : int
-            If the half_steps_pattern is an empty list, then use the number
-            of semitones instead. (Or trigger a mapping from 12 to 21.)
-
-        prefer_sharps : boolean
-            If we are mapping from 12 to 21 semitones, we need to know
-            whether or not to prefer sharps or flats.
-        """
-
-    def get_number_of_semitones(self):
-        """
-        The number of semitones is the number of notes in the temperament.
-
-        Returns
-        -------
-        int
-            The number of notes in the scale
-        """
-
-    def get_note_names(self):
-        """
-        The notes defined by the temperament are used to build the scale.
-
-        Returns
-        -------
-        list
-            The notes defined by the temperament
-        """
-
-    def get_scale(self, pitch_format=None):
-        """
-        The notes in the scale are a subset of the notes defined by the
-        temperament.
-
-        Returns
-        -------
-        list
-            The notes in the scale
-        """
-
-    def get_scale_and_octave_deltas(self, pitch_format=None):
-        """
-        The notes in the scale are a subset of the notes defined by the
-        temperament.
-
-        Returns
-        -------
-        list
-            The notes in the scale
-        list
-        The octave deltas (either 0 or 1) are used to mark notes above
-        B#, which would be in the next octave, e.g., G3, A3, B3, C4...
         """
 ```
 

--- a/src/musicUtils/.archive/currentpitch.py
+++ b/src/musicUtils/.archive/currentpitch.py
@@ -125,8 +125,9 @@ class CurrentPitch:
                 self._number = self._t.get_nearest_freq_index(self._freq)
         elif isinstance(pitch_name, str):
             # Assume it is a name of some sort.
-            scale = self._ks.get_scale()
-            self._generic_name = scale.convert_to_generic_note_name(pitch_name)[0]
+            self._generic_name = self._ks.scale.convert_to_generic_note_name(
+                pitch_name
+            )[0]
             self._semitone_index = self._t.get_modal_index(self._generic_name)
             self._octave = octave
             self._freq = self._t.get_freq_by_modal_index_and_octave(
@@ -145,7 +146,7 @@ class CurrentPitch:
         number_of_half_steps : int
             The transposition in half steps
         """
-        self._generic_name, delta_octave = self._ks.semitone_transform(
+        self._generic_name, delta_octave = self._ks.scale.semitone_transform(
             self._generic_name, number_of_half_steps
         )[0:2]
 
@@ -167,7 +168,7 @@ class CurrentPitch:
         number_of_scalar_steps : int
             The transposition in scalar steps
         """
-        self._generic_name, delta_octave = self._ks.scalar_transform(
+        self._generic_name, delta_octave = self._ks.scale.scalar_transform(
             self._generic_name, number_of_scalar_steps
         )[0:2]
 
@@ -193,7 +194,7 @@ class CurrentPitch:
         float
             The frequency of the note at the specified interval.
         """
-        generic_name, delta_octave = self._ks.semitone_transform(
+        generic_name, delta_octave = self._ks.scale.semitone_transform(
             self._generic_name, number_of_half_steps
         )[0:2]
         semitone_index = self._t.get_modal_index(generic_name)
@@ -215,7 +216,7 @@ class CurrentPitch:
         float
             The frequency of the note at the specified interval.
         """
-        generic_name, delta_octave = self._ks.scalar_transform(
+        generic_name, delta_octave = self._ks.scale.scalar_transform(
             self._generic_name, number_of_scalar_steps
         )[0:2]
         semitone_index = self._t.get_modal_index(generic_name)

--- a/src/musicUtils/.archive/currentpitch.py
+++ b/src/musicUtils/.archive/currentpitch.py
@@ -125,7 +125,8 @@ class CurrentPitch:
                 self._number = self._t.get_nearest_freq_index(self._freq)
         elif isinstance(pitch_name, str):
             # Assume it is a name of some sort.
-            self._generic_name = self._ks.convert_to_generic_note_name(pitch_name)[0]
+            scale = self._ks.get_scale()
+            self._generic_name = scale.convert_to_generic_note_name(pitch_name)[0]
             self._semitone_index = self._t.get_modal_index(self._generic_name)
             self._octave = octave
             self._freq = self._t.get_freq_by_modal_index_and_octave(

--- a/src/musicUtils/.archive/currentpitch.py
+++ b/src/musicUtils/.archive/currentpitch.py
@@ -53,6 +53,7 @@ class CurrentPitch:
             )
         else:
             self._ks = keysignature
+        self._s = self._ks.get_scale()
 
         self._semitone_index = i
         self._octave = octave
@@ -125,9 +126,7 @@ class CurrentPitch:
                 self._number = self._t.get_nearest_freq_index(self._freq)
         elif isinstance(pitch_name, str):
             # Assume it is a name of some sort.
-            self._generic_name = self._ks.scale.convert_to_generic_note_name(
-                pitch_name
-            )[0]
+            self._generic_name = self._s.convert_to_generic_note_name(pitch_name)[0]
             self._semitone_index = self._t.get_modal_index(self._generic_name)
             self._octave = octave
             self._freq = self._t.get_freq_by_modal_index_and_octave(
@@ -146,7 +145,7 @@ class CurrentPitch:
         number_of_half_steps : int
             The transposition in half steps
         """
-        self._generic_name, delta_octave = self._ks.scale.semitone_transform(
+        self._generic_name, delta_octave = self._s.semitone_transform(
             self._generic_name, number_of_half_steps
         )[0:2]
 
@@ -168,7 +167,7 @@ class CurrentPitch:
         number_of_scalar_steps : int
             The transposition in scalar steps
         """
-        self._generic_name, delta_octave = self._ks.scale.scalar_transform(
+        self._generic_name, delta_octave = self._s.scalar_transform(
             self._generic_name, number_of_scalar_steps
         )[0:2]
 
@@ -194,7 +193,7 @@ class CurrentPitch:
         float
             The frequency of the note at the specified interval.
         """
-        generic_name, delta_octave = self._ks.scale.semitone_transform(
+        generic_name, delta_octave = self._s.semitone_transform(
             self._generic_name, number_of_half_steps
         )[0:2]
         semitone_index = self._t.get_modal_index(generic_name)
@@ -216,7 +215,7 @@ class CurrentPitch:
         float
             The frequency of the note at the specified interval.
         """
-        generic_name, delta_octave = self._ks.scale.scalar_transform(
+        generic_name, delta_octave = self._s.scalar_transform(
             self._generic_name, number_of_scalar_steps
         )[0:2]
         semitone_index = self._t.get_modal_index(generic_name)

--- a/src/musicUtils/.archive/keysignature.py
+++ b/src/musicUtils/.archive/keysignature.py
@@ -16,31 +16,15 @@ key/mode combination.
 
 from scale import Scale
 from musicutils import (
-    strip_accidental,
     normalize_pitch,
-    is_a_sharp,
-    is_a_flat,
     find_sharp_index,
     find_flat_index,
 )
 from musicutils import (
-    ALL_NOTES,
     CHROMATIC_NOTES_SHARP,
     CHROMATIC_NOTES_FLAT,
-    SOLFEGE_SHARP,
-    SOLFEGE_FLAT,
-    EAST_INDIAN_SHARP,
-    EAST_INDIAN_FLAT,
-    SCALAR_NAMES_SHARP,
-    SCALAR_NAMES_FLAT,
-    GENERIC_NOTE_NAME,
-    LETTER_NAME,
-    SOLFEGE_NAME,
-    EAST_INDIAN_SOLFEGE_NAME,
-    SCALAR_MODE_NUMBER,
-    CUSTOM_NAME,
     EQUIVALENT_FLATS,
-    EQUIVALENT_SHARPS
+    EQUIVALENT_SHARPS,
 )
 
 
@@ -241,11 +225,11 @@ class KeySignature:
             print("bad key type", type(key))
 
         if len(self.half_steps) == 0:
-            self._scale = Scale(
+            self.scale = Scale(
                 starting_index=i, number_of_semitones=number_of_semitones, key=self.key
             )
         else:
-            self._scale = Scale(
+            self.scale = Scale(
                 half_steps_pattern=self.half_steps,
                 starting_index=i,
                 number_of_semitones=number_of_semitones,
@@ -255,14 +239,13 @@ class KeySignature:
 
         # The generic names of the notes found in the scale defined by
         # this key and mode
-        self.generic_scale = self._scale.get_scale()
-        self.number_of_semitones = self._scale.get_number_of_semitones()
+        self.number_of_semitones = self.scale.get_number_of_semitones()
         self.fixed_solfege = False
 
-        if self._scale.letter_names is not None:
-            self.notes_in_scale = self._scale.letter_names[:]
+        if self.scale.letter_names is not None:
+            self.notes_in_scale = self.scale.letter_names[:]
         else:
-            self.notes_in_scale = self._scale.get_scale()
+            self.notes_in_scale = self.scale.get_scale()
 
         self.key_signature = "%s %s" % (self.key, self.mode)
 
@@ -277,20 +260,20 @@ class KeySignature:
         Parameters
         ----------
         state : boolean
-            State to set FIxed Solfege: True or False
+            State to set fixed Solfege: True or False
         """
-        self.fixed_solfege = state
+        self.scale.set_fixed_solfege(state)
 
     def get_fixed_solfege(self):
         """
-        Returns the Fixed Solfege state
+        Returns the fixed Solfege state
 
         Returns
         -------
         boolean
             State of fixed Solfege
         """
-        return self.fixed_solfege
+        return self.scale.get_fixed_solfege()
 
     def get_notes_in_scale(self):
         """
@@ -303,7 +286,7 @@ class KeySignature:
 
         NOTE: The internal definition of the scale includes the octave.
         """
-        return self.notes_in_scale[:-1]
+        return self.scale.notes_in_scale[:-1]
 
     def get_mode_length(self):
         """
@@ -314,7 +297,7 @@ class KeySignature:
         int
             The number of (scalar) notes in the scale.
         """
-        return len(self.notes_in_scale) - 1
+        return len(self.scale.notes_in_scale) - 1
 
     def get_number_of_semitones(self):
         """
@@ -338,747 +321,7 @@ class KeySignature:
         obj
             Scale object
         """
-        return self._scale
-
-    def set_custom_note_names(self, custom_names):
-        """
-        Set the custom note names in the Scale object
-
-        Parameters
-        ----------
-        custom_names : list
-            List of custom names
-        """
-        return self._scale.set_custom_note_names(custom_names)
-
-    def get_custom_note_names(self):
-        """
-        Get the custom note names in the Scale object
-
-        Returns
-        ----------
-        list
-            List of custom names
-        """
-        return self._scale.get_custom_note_names()
-
-    def _convert_from_note_name(self, note_name, target_list):
-        """
-        Convert from a note name to a format specified in the target list.
-        """
-        note_name = normalize_pitch(note_name)
-        # Maybe it is already in the list?
-        if note_name in target_list:
-            return note_name, 0
-        if self.number_of_semitones != 12:
-            print("Cannot convert %s to a letter name." % note_name)
-            return note_name, -1
-
-        if note_name in self._scale.note_names:
-            # First find the corresponding letter name
-            letter_name = CHROMATIC_NOTES_SHARP[self._scale.note_names.index(note_name)]
-            # Next, find the closest note in the scale.
-            i, distance, error = self.closest_note(letter_name)[1:]
-            # Use the index to get the corresponding solfege note
-            if error < 0:
-                print("Cannot find closest note to ", letter_name)
-                return note_name, -1
-            if distance == 0:
-                return target_list[i], 0
-            # Remove any accidental
-            target_note, delta = strip_accidental(target_list[i])
-            # Add back in the appropriate accidental
-            delta += distance
-            return target_note + ["bb", "b", "", "#", "x"][delta + 2], 0
-
-        print("Note name %s not found." % note_name)
-        return note_name, -1
-
-    def _find_moveable(self, note_name, sharp_scale, flat_scale, prefer_sharps):
-        """
-        Find the equivalent moveable note.
-        """
-        note_name = normalize_pitch(note_name)
-        if note_name in sharp_scale:
-            return note_name, 0
-        if note_name in flat_scale:
-            return note_name, 0
-        if self.number_of_semitones != 12:
-            print("Cannot convert %s" % note_name)
-            return note_name, -1
-
-        if note_name in self._scale.note_names:
-            if prefer_sharps:
-                return sharp_scale[self._scale.note_names.index(note_name)], 0
-            return flat_scale[self._scale.note_names.index(note_name)], 0
-
-        print("Cannot convert %s" % note_name)
-        return note_name, -1
-
-    def _generic_note_name_to_letter_name(self, note_name, prefer_sharps=True):
-        """
-        Convert from a generic note name as defined by the temperament
-        to a letter name used by 12-semitone temperaments.
-        NOTE: Only for temperaments with 12 semitones.
-        """
-        note_name = normalize_pitch(note_name)
-        # Maybe it is already a letter name?
-        if is_a_sharp(note_name):
-            return note_name, 0
-        if is_a_flat(note_name):
-            return note_name, 0
-        if self.number_of_semitones == 21:
-            return ALL_NOTES[self._scale.note_names.index(note_name)], 0
-        if self.number_of_semitones != 12:
-            print("Cannot convert %s to a letter name." % note_name)
-            return note_name, -1
-
-        if note_name in self._scale.note_names:
-            if prefer_sharps:
-                return CHROMATIC_NOTES_SHARP[self._scale.note_names.index(note_name)], 0
-            return CHROMATIC_NOTES_FLAT[self._scale.note_names.index(note_name)], 0
-
-        print("Note name %s not found." % note_name)
-        return note_name, -1
-
-    def _generic_note_name_to_solfege(self, note_name, prefer_sharps=True):
-        """
-        Convert from a generic note name as defined by the temperament
-        to a solfege note used by 12-semitone temperaments.
-        NOTE: Only for temperaments with 12 semitones.
-        """
-        if self.fixed_solfege:
-            return self._convert_from_note_name(note_name, self._scale.solfege_notes)
-
-        return self._find_moveable(
-            note_name, SOLFEGE_SHARP, SOLFEGE_FLAT, prefer_sharps
-        )
-
-    def _generic_note_name_to_east_indian_solfege(self, note_name, prefer_sharps=True):
-        """
-        Convert from a generic note name as defined by the temperament
-        to an East Indian solfege note used by 12-semitone temperaments.
-        NOTE: Only for temperaments with 12 semitones.
-        """
-
-        if self.fixed_solfege:
-            return self._convert_from_note_name(
-                note_name, self._scale.east_indian_solfege_notes
-            )
-
-        return self._find_moveable(
-            note_name, EAST_INDIAN_SHARP, EAST_INDIAN_FLAT, prefer_sharps
-        )
-
-    def _generic_note_name_to_scalar_mode_number(self, note_name, prefer_sharps=True):
-        """
-        Convert from a generic note name as defined by the temperament
-        to a scalar mode number used by 12-semitone temperaments.
-        NOTE: Only for temperaments with 12 semitones.
-        """
-
-        if self.fixed_solfege:
-            return self._convert_from_note_name(
-                note_name, self._scale.scalar_mode_numbers
-            )
-
-        return self._find_moveable(
-            note_name, SCALAR_NAMES_SHARP, SCALAR_NAMES_FLAT, prefer_sharps
-        )
-
-    def _generic_note_name_to_custom_note_name(self, note_name):
-        """
-        Convert from a generic note name as defined by the temperament
-        to a custom_note_name used by 12-semitone temperaments.
-        NOTE: Only for temperaments with 12 semitones.
-        """
-
-        return self._convert_from_note_name(note_name, self._scale.custom_note_names)
-
-    def modal_pitch_to_letter(self, modal_index):
-        """
-        Given a modal number, return the corresponding pitch in the scale
-        (and any change in octave).
-
-        Parameters
-        ----------
-        modal_index : int
-            The modal index specifies an index into the scale. If the
-            index is >= mode length or < 0, a relative change in octave
-            is also calculated.
-
-        Returns
-        -------
-        str
-            The pitch that is the result of indexing the scale by the
-            modal index.
-
-        int
-            The relative change in octave due to mapping the modal index
-            to the mode length
-        """
-        mode_length = self.get_mode_length()
-        modal_index = int(modal_index)
-        delta_octave = int(modal_index / mode_length)
-        if modal_index < 0:
-            delta_octave -= 1
-            while modal_index < 0:
-                modal_index += mode_length
-        while modal_index > mode_length - 1:
-            modal_index -= mode_length
-        return self.notes_in_scale[modal_index], delta_octave
-
-    def note_in_scale(self, target):
-        """
-        Given a pitch, check to see if it is in the scale.
-
-        Parameters
-        ----------
-        target : str
-            The target pitch specified as a pitch letter, e.g., c#, fb.
-
-        Returns
-        -------
-        boolean
-            True if the note is in the scale
-        """
-        return self.closest_note(target)[2] == 0
-
-    def _map_to_semitone_range(self, i, delta_octave):
-        """
-        Ensure that an index value is within the range of the temperament, e.g.,
-        i == 12 would be mapped to 0 with a change in octave +1 for a
-        temperament with 12 semitones.
-
-        Parameters
-        ----------
-        i : int
-            Index value into semitones
-
-        delta_octave : int
-            Any previous change in octave that needs to be preserved
-
-        Returns
-        -------
-        int
-            Index mapped to semitones
-
-        int
-            Any additonal change in octave due to mapping
-        """
-        while i < 0:
-            i += self.number_of_semitones
-            delta_octave -= 1
-        while i > self.number_of_semitones - 1:
-            i -= self.number_of_semitones
-            delta_octave += 1
-        return i, delta_octave
-
-    def semitone_transform(self, starting_pitch, number_of_half_steps):
-        """
-        Given a starting pitch, add a semitone transform and return
-        the resultant pitch (and any change in octave).
-
-        Parameters
-        ----------
-        starting_pitch : str
-            The starting pitch specified as a pitch letter, e.g., c#, fb.
-
-        number_of_half_steps : int
-            Half steps are steps in the notes defined by the temperament
-
-        Returns
-        -------
-        str
-            The pitch that is the number of half steps from the starting
-            pitch.
-
-        int
-            The relative change in octave between the starting pitch and the
-            new pitch.
-
-        int
-            error code
-        """
-        starting_pitch = normalize_pitch(starting_pitch)
-        original_notation = self._scale.pitch_name_type(starting_pitch)
-        delta_octave = 0
-        if self.number_of_semitones == 12:
-            if original_notation == LETTER_NAME:
-                if is_a_sharp(starting_pitch):
-                    i = find_sharp_index(starting_pitch)
-                    i += number_of_half_steps
-                    i, delta_octave = self._map_to_semitone_range(i, delta_octave)
-                    return CHROMATIC_NOTES_SHARP[i], delta_octave, 0
-                if is_a_flat(starting_pitch):
-                    i = find_flat_index(starting_pitch)
-                    i += number_of_half_steps
-                    i, delta_octave = self._map_to_semitone_range(i, delta_octave)
-                    return CHROMATIC_NOTES_FLAT[i], delta_octave, 0
-                stripped_pitch, delta = strip_accidental(starting_pitch)
-                if stripped_pitch in self._scale.note_names:
-                    note_name = stripped_pitch
-                    error = 0
-                else:
-                    note_name, error = self._scale.convert_to_generic_note_name(
-                        stripped_pitch, self.fixed_solfege
-                    )
-                if error == 0:
-                    if note_name in self._scale.note_names:
-                        i = self._scale.note_names.index(note_name)
-                        i += number_of_half_steps
-                        i, delta_octave = self._map_to_semitone_range(
-                            i + delta, delta_octave
-                        )
-                        return self._scale.note_names[i], delta_octave, 0
-                print("Cannot find %s in note names." % starting_pitch)
-                return starting_pitch, 0, -1
-
-            note_name, error = self._scale.convert_to_generic_note_name(
-                starting_pitch, self.fixed_solfege
-            )
-            stripped_pitch, delta = strip_accidental(note_name)  # starting_pitch)
-            if stripped_pitch in self._scale.note_names:
-                i = self._scale.note_names.index(stripped_pitch)
-                i += number_of_half_steps
-                i, delta_octave = self._map_to_semitone_range(i + delta, delta_octave)
-                if original_notation == SOLFEGE_NAME:
-                    return (
-                        self._generic_note_name_to_solfege(
-                            self._scale.note_names[i], "#" in starting_pitch
-                        )[0],
-                        delta_octave,
-                        0,
-                    )
-                if original_notation == EAST_INDIAN_SOLFEGE_NAME:
-                    return (
-                        self._generic_note_name_to_east_indian_solfege(
-                            self._scale.note_names[i], "#" in starting_pitch
-                        )[0],
-                        delta_octave,
-                        0,
-                    )
-                if original_notation == SCALAR_MODE_NUMBER:
-                    return (
-                        self._generic_note_name_to_scalar_mode_number(
-                            self._scale.note_names[i], "#" in starting_pitch
-                        )[0],
-                        delta_octave,
-                        0,
-                    )
-                return self._scale.note_names[i], delta_octave, 0
-            print("Cannot find %s in note names." % starting_pitch)
-            return starting_pitch, 0, -1
-
-        def __calculate_increment(delta, j):
-            """
-            When there both sharps and flats in a scale, we skip some of the
-            accidental as we navigate the semitones.
-            """
-            if delta == 0 and j % 3 == 2:
-                return 2
-            if delta == 1 and j % 3 == 1:
-                return 2
-            if delta == -1 and j % 3 == 2:
-                return 2
-            return 1
-
-        stripped_pitch, delta = strip_accidental(starting_pitch)
-        # If there are 21 semitones, assume c, c#, db, d, d#,
-        # eb... but still go from c# to d or db to c.
-        if self.number_of_semitones == 21:
-            if starting_pitch in ALL_NOTES:
-                i = ALL_NOTES.index(starting_pitch)
-                if number_of_half_steps > 0:
-                    for j in range(number_of_half_steps):
-                        i += __calculate_increment(delta, j)
-                else:
-                    for j in range(-number_of_half_steps):
-                        i -= __calculate_increment(delta, j)
-                i, delta_octave = self._map_to_semitone_range(i, delta_octave)
-                return ALL_NOTES[i], delta_octave, 0
-            if stripped_pitch in self._scale.note_names:
-                i = self._scale.note_names.index(stripped_pitch)
-                if number_of_half_steps > 0:
-                    for j in range(number_of_half_steps):
-                        i += __calculate_increment(delta, j)
-                else:
-                    for j in range(-number_of_half_steps):
-                        i -= __calculate_increment(delta, j)
-                i, delta_octave = self._map_to_semitone_range(i, delta_octave)
-                return self._scale.note_names[i], delta_octave, 0
-
-        if stripped_pitch in self._scale.note_names:
-            i = self._scale.note_names.index(stripped_pitch)
-            i += number_of_half_steps
-            i, delta_octave = self._map_to_semitone_range(i + delta, delta_octave)
-            return self._scale.note_names[i], delta_octave, 0
-
-        print("Cannot find %s in note names." % starting_pitch)
-        return starting_pitch, 0, -1
-
-    def _map_to_scalar_range(self, i, delta_octave):
-        """
-        Ensure that an index value is within the range of the scale, e.g.,
-        i == 8 would be mapped to 0 with a change in octave +1 for a
-        7-tone scale.
-
-        Parameters
-        ----------
-        i : int
-            Index value into scale
-
-        delta_octave : int
-            Any previous change in octave that needs to be preserved
-
-        Returns
-        -------
-        int
-            Index mapped to scale
-
-        int
-            Any additonal change in octave due to mapping
-        """
-        mode_length = self.get_mode_length()
-        while i < 0:
-            i += mode_length
-            delta_octave -= 1
-        while i > mode_length - 1:
-            i -= mode_length
-            delta_octave += 1
-        return i, delta_octave
-
-    def scalar_transform(self, starting_pitch, number_of_scalar_steps):
-        """
-        Given a starting pitch, add a scalar transform and return
-        the resultant pitch (and any change in octave).
-
-        Parameters
-        ----------
-        starting_pitch : str
-            The starting pitch specified as a pitch letter, e.g., c#, fb.
-            Note that the starting pitch may or may not be in the scale.
-
-        number_of_scalar_steps : int
-            Scalar steps are steps in the scale (as opposed to half-steps)
-
-        Returns
-        -------
-        str
-            The pitch that is the number of scalar steps from the starting
-            pitch.
-
-        int
-            The relative change in octave between the starting pitch and the
-            new pitch.
-
-        int
-            error code
-        """
-        starting_pitch = normalize_pitch(starting_pitch)
-        original_notation = self._scale.pitch_name_type(starting_pitch)
-        prefer_sharps = "#" in starting_pitch
-        # The calculation is done in the generic note namespace
-        generic_pitch = self._scale.convert_to_generic_note_name(
-            starting_pitch, self.fixed_solfege
-        )[0]
-        # First, we need to find the closest note to our starting
-        # pitch.
-        closest_index, distance, error = self.closest_note(generic_pitch)[1:]
-        if error < 0:
-            return starting_pitch, 0, error
-        # Next, we add the scalar interval -- the steps are in the
-        # scale.
-        new_index = closest_index + number_of_scalar_steps
-        # We also need to determine if we will be travelling more than
-        # one octave.
-        mode_length = self.get_mode_length()
-        delta_octave = int(new_index / mode_length)
-
-        # We need an index value between 0 and mode length - 1.
-        normalized_index = new_index
-        while normalized_index < 0:
-            normalized_index += mode_length
-        while normalized_index > mode_length - 1:
-            normalized_index -= mode_length
-        generic_new_note = self.generic_scale[normalized_index]
-        new_note = self._restore_format(
-            generic_new_note, original_notation, prefer_sharps
-        )
-
-        # We need to keep track of whether or not we crossed C, which
-        # is the octave boundary.
-        if new_index < 0:
-            delta_octave -= 1
-
-        # Do we need to take into account the distance from the
-        # closest scalar note?
-        if distance == 0:
-            return new_note, delta_octave, 0
-        i = self._scale.note_names.index(generic_new_note)
-        i, delta_octave = self._map_to_scalar_range(i - distance, delta_octave)
-        return (
-            self._restore_format(
-                self._scale.note_names[i], original_notation, prefer_sharps
-            ),
-            delta_octave,
-            0,
-        )
-
-    def generic_note_name_convert_to_type(
-        self, pitch_name, target_type, prefer_sharps=True
-    ):
-        """
-        Given a generic note name, convert it to a pitch name type.
-
-        Parameters
-        ----------
-        pitch_name : str
-            Source generic note name
-
-        target_type : str
-            One of the predefined types, e.g., LETTER_NAME, SOLFEGE_NAME, etc.
-
-        prefer_sharps : boolean
-            If there is a choice, should we use a sharp or a flat?
-
-        Returns
-        -------
-        str
-            Converted note name
-        """
-        return self._restore_format(pitch_name, target_type, prefer_sharps)
-
-    def _restore_format(self, pitch_name, original_notation, prefer_sharps):
-        """
-        Format convertor (could be done with a dictionary?)
-        """
-        if original_notation == GENERIC_NOTE_NAME:
-            return pitch_name
-        if original_notation == LETTER_NAME:
-            return self._generic_note_name_to_letter_name(
-                pitch_name, prefer_sharps
-            )[0]
-        if original_notation == SOLFEGE_NAME:
-            return self._generic_note_name_to_solfege(pitch_name, prefer_sharps)[0]
-        if original_notation == CUSTOM_NAME:
-            return self._generic_note_name_to_custom_note_name(pitch_name)[0]
-        if original_notation == SCALAR_MODE_NUMBER:
-            return self._generic_note_name_to_scalar_mode_number(pitch_name)[0]
-        if original_notation == EAST_INDIAN_SOLFEGE_NAME:
-            return self._generic_note_name_to_east_indian_solfege(pitch_name)[0]
-        return pitch_name
-
-    def _pitch_to_note_number(self, pitch_name, octave):
-        """
-        Find the pitch number, e.g., A4 --> 57
-        """
-        generic_name = self._scale.convert_to_generic_note_name(
-            pitch_name, self.fixed_solfege
-        )[0]
-        ni = self._scale.note_names.index(generic_name)
-        i = (octave * self.number_of_semitones) + ni
-        return int(i)
-
-    def semitone_distance(self, pitch_a, octave_a, pitch_b, octave_b):
-        """
-        Calculate the distance between two notes in semitone steps
-
-        Parameters
-        ----------
-        pitch_a : str
-            Pitch name one of two
-        octave_a : int
-            Octave number one of two
-        pitch_b : str
-            Pitch name two of two
-        octave_b : int
-            Octave number two of two
-
-        Returns
-        -------
-        int
-            Distance calculated in semitone steps
-        """
-        return self._pitch_to_note_number(
-            pitch_b, octave_b
-        ) - self._pitch_to_note_number(pitch_a, octave_a)
-
-    def scalar_distance(self, pitch_a, octave_a, pitch_b, octave_b):
-        """
-        Calculate the distance between two notes in scalar steps
-
-        Parameters
-        ----------
-        pitch_a : str
-            Pitch name one of two
-        octave_a : int
-            Octave number one of two
-        pitch_b : str
-            Pitch name two of two
-        octave_b : int
-            Octave number two of two
-
-        Returns
-        -------
-        int
-            Distance calculated in scalar steps
-        int
-            Any semitone rounding error in the calculation
-        """
-        closest1 = self.closest_note(pitch_a)
-        closest2 = self.closest_note(pitch_b)
-        a = closest1[1] + octave_a * self.get_mode_length()
-        b = closest2[1] + octave_b * self.get_mode_length()
-        return b - a, closest1[2] + closest2[2]
-
-    def invert(
-        self, pitch_name, octave, invert_point_pitch, invert_point_octave, invert_mode
-    ):
-        """
-        Invert will rotate a series of notes around an invert point.
-        There are three different invert modes: even, odd, and
-        scalar. In even and odd modes, the rotation is based on half
-        steps. In even and scalar mode, the point of rotation is the
-        given note. In odd mode, the point of rotation is shifted up
-        by a 1/4 step, enabling rotation around a point between two
-        notes. In "scalar" mode, the scalar interval is preserved
-        around the point of rotation.
-
-        Parameters
-        ----------
-        pitch_name : str
-            The pitch name of the note to be rotated
-        octave : int
-            The octave of the note to be rotated
-        invert_point_name : str
-            The pitch name of the axis of inversion
-        invert_point_octave : int
-            The octave of the axis of inversion
-
-        Returns
-        -------
-        str
-            Pitch name of the inverted note
-        int
-            Octave of the inverted note
-        """
-        if isinstance(invert_mode, int):
-            if invert_mode % 2 == 0:
-                invert_mode = "even"
-            else:
-                invert_mode = "odd"
-
-        if invert_mode in ["even", "odd"]:
-            delta = self.semitone_distance(
-                invert_point_pitch, invert_point_octave, pitch_name, octave
-            )
-            if invert_mode == "even":
-                delta *= 2
-            elif invert_mode == "odd":
-                delta = 2 * delta - 1
-            inverted_pitch, delta_octave = self.semitone_transform(pitch_name, -delta)[
-                0:2
-            ]
-            return inverted_pitch, octave + delta_octave
-
-        if invert_mode == "scalar":
-            delta = self.scalar_distance(
-                invert_point_pitch, invert_point_octave, pitch_name, octave
-            )[0]
-            delta *= 2
-            inverted_pitch, delta_octave = self.scalar_transform(pitch_name, -delta)[
-                0:2
-            ]
-            return inverted_pitch, octave + delta_octave
-
-        print("Unknown invert mode", invert_mode)
-        return pitch_name, octave
-
-    def closest_note(self, target):
-        """
-        Given a target pitch, what is the closest note in the current
-        key signature (key and mode)?
-
-        Parameters
-        ----------
-        target : str
-            target pitch specified as a pitch letter, e.g., c#, fb
-
-        Returns
-        -------
-        str
-            The closest pitch to the target pitch in the scale.
-        int
-            The scalar index value of the closest pitch in the scale
-            (If the target is midway between two scalar pitches, the
-            lower pitch is returned.)
-        int
-            The distance in semitones (half steps) from the target
-            pitch to the scalar pitch (If the target is higher than
-            the scalar pitch, then distance > 0. If the target is
-            lower than the scalar pitch then distance < 0. If the
-            target matches a scale pitch, then distance = 0.)
-        int
-            error code (0 means success)
-        """
-        target = normalize_pitch(target)
-        original_notation = self._scale.pitch_name_type(target)
-        prefer_sharps = "#" in target
-        # The calculation is done in the generic note namespace
-        target = self._scale.convert_to_generic_note_name(target, self.fixed_solfege)[0]
-        stripped_target, delta = strip_accidental(target)
-        if stripped_target in self._scale.note_names:
-            i = self._scale.note_names.index(stripped_target)
-            i = self._map_to_semitone_range(i + delta, 0)[0]
-        target = self._scale.note_names[i]
-
-        # First look for an exact match.
-        for i in range(self.get_mode_length()):
-            if target == self.generic_scale[i]:
-                return (
-                    self._restore_format(target, original_notation, prefer_sharps),
-                    i,
-                    0,
-                    0,
-                )
-
-        # Then look for the nearest note in the scale.
-        if target in self._scale.note_names:
-            idx = self._scale.note_names.index(target)
-            # Look up for a note in the scale.
-            distance = self.number_of_semitones  # max distance
-            n = 0
-            for i in range(self.get_mode_length()):
-                ii = self._scale.note_names.index(self.generic_scale[i])
-                n = ii - idx
-                m = ii + self.number_of_semitones - idx
-                if abs(n) < abs(distance):
-                    closest_note = self.generic_scale[i]
-                    distance = n
-                if abs(m) < abs(distance):
-                    closest_note = self.generic_scale[i]
-                    distance = m
-            if distance < self.number_of_semitones:
-                return (
-                    self._restore_format(
-                        closest_note, original_notation, prefer_sharps
-                    ),
-                    self.generic_scale.index(closest_note),
-                    distance,
-                    0,
-                )
-
-            print("Closest note to %s not found." % target)
-            return (
-                self._restore_format(target, original_notation, prefer_sharps),
-                0,
-                0,
-                -1,
-            )
-
-        print("Note %s not found." % target)
-        return self._restore_format(target, original_notation, prefer_sharps), 0, 0, -1
+        return self.scale
 
     def _prefer_sharps(self, key, mode):
         """
@@ -1093,7 +336,7 @@ class KeySignature:
         half_steps = []
         for i in range(len(self.half_steps)):
             half_steps.append(str(self.half_steps[i]))
-        scale = " ".join(self.notes_in_scale)
+        scale = " ".join(self.scale.notes_in_scale)
         if len(self.key) > 1:
             key = "%s%s" % (self.key[0].upper(), self.key[1:])
         else:

--- a/src/musicUtils/.archive/musicutils_unittest.py
+++ b/src/musicUtils/.archive/musicutils_unittest.py
@@ -318,14 +318,15 @@ class MusicUtilsTestCase(unittest.TestCase):
 
     def test_chromatic_key_signature(self):
         ks = KeySignature(mode="chromatic", key="c")
+        s = ks.get_scale()
         self.assertEqual(ks.get_mode_length(), 12)
         self.assertEqual(ks.get_number_of_semitones(), 12)
-        self.assertEqual(ks.scale.scalar_transform("c", 2)[0], "d")
-        self.assertEqual(ks.scale.scalar_transform("c#", 2)[0], "d#")
-        self.assertEqual(ks.scale.semitone_transform("c", 2)[0], "d")
-        self.assertEqual(ks.scale.semitone_transform("c#", 2)[0], "d#")
-        self.assertEqual(ks.scale.semitone_transform("b", 1)[0], "c")
-        self.assertEqual(ks.scale._map_to_scalar_range(13, 0)[0], 1)
+        self.assertEqual(s.scalar_transform("c", 2)[0], "d")
+        self.assertEqual(s.scalar_transform("c#", 2)[0], "d#")
+        self.assertEqual(s.semitone_transform("c", 2)[0], "d")
+        self.assertEqual(s.semitone_transform("c#", 2)[0], "d#")
+        self.assertEqual(s.semitone_transform("b", 1)[0], "c")
+        self.assertEqual(s._map_to_scalar_range(13, 0)[0], 1)
 
     def test_third_comma_meantone_key_signature(self):
         t = Temperament(name="third comma meantone")
@@ -334,74 +335,92 @@ class MusicUtilsTestCase(unittest.TestCase):
             number_of_semitones=t.get_number_of_semitones_in_octave(),
             mode=[2, 2, 1, 2, 2, 2, 7, 1],
         )
+        s = ks.get_scale()
         self.assertEqual(ks.get_mode_length(), 8)
         self.assertEqual(ks.get_number_of_semitones(), 19)
         self.assertEqual(len(ks.get_notes_in_scale()), 8)
         self.assertEqual(ks.get_notes_in_scale()[7], "n18")
-        self.assertEqual(ks.scale.closest_note("n12")[0], "n11")
-        self.assertEqual(ks.scale.scalar_transform("n5", 2)[0], "n9")
-        self.assertEqual(ks.scale.closest_note("n10#")[0], "n11")
+        self.assertEqual(s.closest_note("n12")[0], "n11")
+        self.assertEqual(s.scalar_transform("n5", 2)[0], "n9")
+        self.assertEqual(s.closest_note("n10#")[0], "n11")
 
     def test_mode_equivalents(self):
         ks = KeySignature(key="e", mode="major")
+        s = ks.get_scale()
         source = ks.scale.normalize_scale(ks.notes_in_scale)
         ks = KeySignature(key="db", mode="minor")
+        s = ks.get_scale()
         target = ks.scale.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="c#", mode="minor")
+        s = ks.get_scale()
         target = ks.scale.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="eb", mode="locrian")
+        s = ks.get_scale()
         target = ks.scale.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="d#", mode="locrian")
+        s = ks.get_scale()
         target = ks.scale.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="b", mode="mixolydian")
+        s = ks.get_scale()
         target = ks.scale.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="a", mode="lydian")
-        target = ks.scale.normalize_scale(ks.notes_in_scale)
+        s = ks.get_scale()
+        target = s.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="g#", mode="phrygian")
-        target = ks.scale.normalize_scale(ks.notes_in_scale)
+        s = ks.get_scale()
+        target = s.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="ab", mode="phrygian")
-        target = ks.scale.normalize_scale(ks.notes_in_scale)
+        s = ks.get_scale()
+        target = s.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="f#", mode="dorian")
-        target = ks.scale.normalize_scale(ks.notes_in_scale)
+        s = ks.get_scale()
+        target = s.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="gb", mode="dorian")
-        target = ks.scale.normalize_scale(ks.notes_in_scale)
+        s = ks.get_scale()
+        target = s.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="e", mode=[2, 2, 1, 2, 2, 2, 1])
-        target = ks.scale.normalize_scale(ks.notes_in_scale)
+        s = ks.get_scale()
+        target = s.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
 
     def test_solfege_mapper(self):
         ks = KeySignature(key="c", mode="major")
-        self.assertEqual(len(ks.scale.solfege_notes), 8)
+        s = ks.get_scale()
+        self.assertEqual(len(s.solfege_notes), 8)
 
         ks = KeySignature(key="c", mode="major pentatonic")
-        self.assertEqual(len(ks.scale.solfege_notes), 6)
-        self.assertEqual(ks.scale.solfege_notes[2], "me")
-        self.assertEqual(ks.scale.solfege_notes[3], "sol")
+        s = ks.get_scale()
+        self.assertEqual(len(s.solfege_notes), 6)
+        self.assertEqual(s.solfege_notes[2], "me")
+        self.assertEqual(s.solfege_notes[3], "sol")
 
         ks = KeySignature(key="c", mode="minor pentatonic")
-        self.assertEqual(len(ks.scale.solfege_notes), 6)
-        self.assertEqual(ks.scale.solfege_notes[2], "fa")
-        self.assertEqual(ks.scale.solfege_notes[3], "sol")
+        s = ks.get_scale()
+        self.assertEqual(len(s.solfege_notes), 6)
+        self.assertEqual(s.solfege_notes[2], "fa")
+        self.assertEqual(s.solfege_notes[3], "sol")
 
         ks = KeySignature(key="c", mode="whole tone")
-        self.assertEqual(len(ks.scale.solfege_notes), 7)
-        self.assertEqual(ks.scale.solfege_notes[2], "me")
-        self.assertEqual(ks.scale.solfege_notes[4], "sol")
+        s = ks.get_scale()
+        self.assertEqual(len(s.solfege_notes), 7)
+        self.assertEqual(s.solfege_notes[2], "me")
+        self.assertEqual(s.solfege_notes[4], "sol")
 
         ks = KeySignature(key="c", mode="chromatic")
-        self.assertEqual(len(ks.scale.solfege_notes), 13)
-        self.assertEqual(ks.scale.solfege_notes[2], "re")
-        self.assertEqual(ks.scale.solfege_notes[3], "meb")
+        s = ks.get_scale()
+        self.assertEqual(len(s.solfege_notes), 13)
+        self.assertEqual(s.solfege_notes[2], "re")
+        self.assertEqual(s.solfege_notes[3], "meb")
 
     def test_convert_to_generic_note_name(self):
         s = Scale()
@@ -493,33 +512,24 @@ class MusicUtilsTestCase(unittest.TestCase):
 
     def test_fixed_solfege(self):
         ks = KeySignature(key="g", mode="major")
-        self.assertEqual(
-            ks.scale.generic_note_name_convert_to_type("n7", SOLFEGE_NAME), "sol"
-        )
-        self.assertEqual(ks.scale.convert_to_generic_note_name("sol")[0], "n7")
-        ks.scale.set_fixed_solfege(True)
-        self.assertTrue(ks.scale.get_fixed_solfege())
+        s = ks.get_scale()
+        self.assertEqual(s.generic_note_name_convert_to_type("n7", SOLFEGE_NAME), "sol")
+        self.assertEqual(s.convert_to_generic_note_name("sol")[0], "n7")
+        s.set_fixed_solfege(True)
+        self.assertTrue(s.get_fixed_solfege())
 
+        self.assertEqual(s.generic_note_name_convert_to_type("n7", SOLFEGE_NAME), "do")
+        self.assertEqual(s.convert_to_generic_note_name("do")[0], "n7")
         self.assertEqual(
-            ks.scale.generic_note_name_convert_to_type("n7", SOLFEGE_NAME), "do"
-        )
-        self.assertEqual(ks.scale.convert_to_generic_note_name("do")[0], "n7")
-        self.assertEqual(
-            ks.scale._generic_note_name_to_letter_name("n6", prefer_sharps=True)[0],
+            s._generic_note_name_to_letter_name("n6", prefer_sharps=True)[0],
             "f#",
         )
         self.assertEqual(
-            ks.scale._generic_note_name_to_solfege("n6", prefer_sharps=True)[0], "ti"
+            s._generic_note_name_to_solfege("n6", prefer_sharps=True)[0], "ti"
         )
-        self.assertEqual(
-            ks.scale._convert_from_note_name("n7", ks.scale.solfege_notes)[0], "do"
-        )
-        self.assertEqual(
-            ks.scale._generic_note_name_to_east_indian_solfege("n7")[0], "sa"
-        )
-        self.assertEqual(
-            ks.scale._generic_note_name_to_scalar_mode_number("n7")[0], "1"
-        )
+        self.assertEqual(s._convert_from_note_name("n7", s.solfege_notes)[0], "do")
+        self.assertEqual(s._generic_note_name_to_east_indian_solfege("n7")[0], "sa")
+        self.assertEqual(s._generic_note_name_to_scalar_mode_number("n7")[0], "1")
 
     def test_get_frequency(self):
         t = Temperament()
@@ -589,25 +599,32 @@ class MusicUtilsTestCase(unittest.TestCase):
 
     def test_meantone_scales(self):
         ks = KeySignature(mode=[], number_of_semitones=21)
+        s = ks.get_scale()
         self.assertEqual(ks.get_mode_length(), 21)
         self.assertEqual(ks.get_number_of_semitones(), 21)
-        self.assertEqual(ks.scale.closest_note("cb")[0], "cb")
-        self.assertEqual(ks.scale.semitone_transform("gb", 1)[0], "g")
-        self.assertEqual(ks.scale.semitone_transform("cb", 3)[0], "d")
-        self.assertEqual(ks.scale.semitone_transform("c", -3)[0], "bb")
+        self.assertEqual(s.closest_note("cb")[0], "cb")
+        self.assertEqual(s.semitone_transform("gb", 1)[0], "g")
+        self.assertEqual(s.semitone_transform("cb", 3)[0], "d")
+        self.assertEqual(s.semitone_transform("c", -3)[0], "bb")
+
         ks = KeySignature(mode=[3, 3, 3, 3, 3, 3, 3], number_of_semitones=21)
-        self.assertEqual(ks.scale.closest_note("cb")[0], "c")
-        self.assertEqual(ks.scale.closest_note("db")[0], "d")
-        self.assertEqual(ks.scale.closest_note("c#")[0], "c")
-        self.assertEqual(ks.scale.scalar_transform("c", 1)[0], "d")
+        s = ks.get_scale()
+        self.assertEqual(s.closest_note("cb")[0], "c")
+        self.assertEqual(s.closest_note("db")[0], "d")
+        self.assertEqual(s.closest_note("c#")[0], "c")
+        self.assertEqual(s.scalar_transform("c", 1)[0], "d")
+
         ks = KeySignature(number_of_semitones=21)
-        self.assertEqual(ks.scale.closest_note("cb")[0], "c")
-        self.assertEqual(ks.scale.closest_note("db")[0], "d")
-        self.assertEqual(ks.scale.closest_note("c#")[0], "c")
-        self.assertEqual(ks.scale.scalar_transform("c", 1)[0], "d")
+        s = ks.get_scale()
+        self.assertEqual(s.closest_note("cb")[0], "c")
+        self.assertEqual(s.closest_note("db")[0], "d")
+        self.assertEqual(s.closest_note("c#")[0], "c")
+        self.assertEqual(s.scalar_transform("c", 1)[0], "d")
+
         ks = KeySignature(key="bb", mode="lydian", number_of_semitones=21)
-        self.assertEqual(ks.scale.closest_note("bb")[0], "bb")
-        self.assertEqual(ks.scale.closest_note("n18")[0], "n17")
+        s = ks.get_scale()
+        self.assertEqual(s.closest_note("bb")[0], "bb")
+        self.assertEqual(s.closest_note("n18")[0], "n17")
 
     def print_scales(self):
         ks = KeySignature(key="c", mode="ionian")

--- a/src/musicUtils/.archive/musicutils_unittest.py
+++ b/src/musicUtils/.archive/musicutils_unittest.py
@@ -29,7 +29,7 @@ from musicutils import (
     UNKNOWN_PITCH_NAME,
     SOLFEGE_NAME,
     EAST_INDIAN_SOLFEGE_NAME,
-    SCALAR_MODE_NUMBER
+    SCALAR_MODE_NUMBER,
 )
 
 
@@ -169,8 +169,8 @@ class MusicUtilsTestCase(unittest.TestCase):
         self.assertTrue(strip_accidental("b")[1] == 0)
 
     def test_normalize_scale(self):
-        ks = KeySignature()
-        normalized_scale = ks._scale._normalize_scale(
+        s = Scale()
+        normalized_scale = s.normalize_scale(
             ["c", "cx", "fbb", "f", "g", "a", "b", "c"]
         )
         self.assertEqual(normalized_scale[1], "d")
@@ -241,90 +241,91 @@ class MusicUtilsTestCase(unittest.TestCase):
         self.assertEqual(ks.get_number_of_semitones(), 12)
 
     def test_closest_note(self):
-        ks = KeySignature(mode="major", key="c")
-        self.assertEqual(ks.closest_note("c")[0], "c")
-        self.assertTrue(ks.note_in_scale("c"))
-        self.assertEqual(ks.closest_note("f#")[0], "f")
-        self.assertFalse(ks.note_in_scale("f#"))
-        self.assertEqual(ks.closest_note("g#")[0], "g")
-        self.assertFalse(ks.note_in_scale("g#"))
-        self.assertEqual(ks.closest_note("cb")[0], "b")
-        self.assertTrue(ks.note_in_scale("cb"))
-        self.assertEqual(ks.closest_note("db")[0], "c")
-        self.assertFalse(ks.note_in_scale("db"))
-        self.assertEqual(ks.closest_note("n10#")[0], "n11")
-        self.assertEqual(ks.closest_note("n10x")[0], "n0")
-        self.assertEqual(ks.closest_note("sol")[0], "sol")
-        self.assertEqual(ks.closest_note("pa")[0], "pa")
+        s = Scale()
+        self.assertEqual(s.closest_note("c")[0], "c")
+        self.assertTrue(s.note_in_scale("c"))
+        self.assertEqual(s.closest_note("f#")[0], "f")
+        self.assertFalse(s.note_in_scale("f#"))
+        self.assertEqual(s.closest_note("g#")[0], "g")
+        self.assertFalse(s.note_in_scale("g#"))
+        self.assertEqual(s.closest_note("cb")[0], "b")
+        self.assertTrue(s.note_in_scale("cb"))
+        self.assertEqual(s.closest_note("db")[0], "c")
+        self.assertFalse(s.note_in_scale("db"))
+        self.assertEqual(s.closest_note("n10#")[0], "n11")
+        self.assertEqual(s.closest_note("n10x")[0], "n0")
+        self.assertEqual(s.closest_note("sol")[0], "sol")
+        self.assertEqual(s.closest_note("pa")[0], "pa")
 
     def test_semitone_distance(self):
-        ks = KeySignature(mode="major", key="c")
-        self.assertEqual(ks.semitone_distance("g", 4, "c", 4), -7)
-        self.assertEqual(ks.semitone_distance("c", 4, "g", 4), 7)
-        self.assertEqual(ks.semitone_distance("g", 3, "c", 4), 5)
-        self.assertEqual(ks.semitone_distance("c", 4, "g", 3), -5)
+        s = Scale()
+        self.assertEqual(s.semitone_distance("g", 4, "c", 4), -7)
+        self.assertEqual(s.semitone_distance("c", 4, "g", 4), 7)
+        self.assertEqual(s.semitone_distance("g", 3, "c", 4), 5)
+        self.assertEqual(s.semitone_distance("c", 4, "g", 3), -5)
 
     def test_scalar_distance(self):
-        ks = KeySignature(mode="major", key="c")
-        self.assertEqual(ks.scalar_distance("g", 4, "c", 4)[0], -4)
-        self.assertEqual(ks.scalar_distance("c", 4, "g", 4)[0], 4)
-        self.assertEqual(ks.scalar_distance("g", 3, "c", 4)[0], 3)
-        self.assertEqual(ks.scalar_distance("c", 4, "g", 3)[0], -3)
+        s = Scale()
+        self.assertEqual(s.scalar_distance("c", 3, "c", 4)[0], 7)
+        self.assertEqual(s.scalar_distance("g", 4, "c", 4)[0], -4)
+        self.assertEqual(s.scalar_distance("c", 4, "g", 4)[0], 4)
+        self.assertEqual(s.scalar_distance("g", 3, "c", 4)[0], 3)
+        self.assertEqual(s.scalar_distance("c", 4, "g", 3)[0], -3)
 
     def test_scalar_transform(self):
-        ks = KeySignature(mode="major", key="c")
-        self.assertEqual(ks.scalar_transform("c", 2)[0], "e")
-        self.assertEqual(ks.scalar_transform("c", 2)[1], 0)  # no change to octave
-        self.assertEqual(ks.scalar_transform("c#", 2)[0], "f")
+        s = Scale()
+        self.assertEqual(s.scalar_transform("c", 2)[0], "e")
+        self.assertEqual(s.scalar_transform("c", 2)[1], 0)  # no change to octave
+        self.assertEqual(s.scalar_transform("c#", 2)[0], "f")
 
     def test_semitone_transform(self):
-        ks = KeySignature(mode="major", key="c")
-        self.assertEqual(ks.semitone_transform("c", 2)[0], "d")
-        self.assertEqual(ks.semitone_transform("c#", 2)[0], "d#")
-        self.assertEqual(ks.semitone_transform("b", 1)[0], "c")
-        self.assertEqual(ks.semitone_transform("b", 1)[1], 1)  # increment octave
-        self.assertEqual(ks.semitone_transform("n3", 1)[0], "n4")
-        self.assertEqual(ks.semitone_transform("n3#", 1)[0], "n5")
-        self.assertEqual(ks.semitone_transform("n0", -1)[0], "n11")
-        self.assertEqual(ks.semitone_transform("n0", -1)[1], -1)  # decrement octave
-        self.assertEqual(ks.semitone_transform("n0b", -1)[0], "n10")
-        self.assertEqual(ks.semitone_transform("n0b", -1)[1], -1)  # decrement octave
-        self.assertEqual(ks.semitone_transform("n1b", -1)[0], "n11")
-        self.assertEqual(ks.semitone_transform("n1b", -1)[1], -1)  # decrement octave
-        self.assertEqual(ks.semitone_transform("n11x", 1)[0], "n2")
-        self.assertEqual(ks.semitone_transform("n11x", 1)[1], 1)  # increment octave
+        s = Scale()
+        self.assertEqual(s.semitone_transform("c", 2)[0], "d")
+        self.assertEqual(s.semitone_transform("c#", 2)[0], "d#")
+        self.assertEqual(s.semitone_transform("b", 1)[0], "c")
+        self.assertEqual(s.semitone_transform("b", 1)[1], 1)  # increment octave
+        self.assertEqual(s.semitone_transform("n3", 1)[0], "n4")
+        self.assertEqual(s.semitone_transform("n3#", 1)[0], "n5")
+        self.assertEqual(s.semitone_transform("n0", -1)[0], "n11")
+        self.assertEqual(s.semitone_transform("n0", -1)[1], -1)  # decrement octave
+        self.assertEqual(s.semitone_transform("n0b", -1)[0], "n10")
+        self.assertEqual(s.semitone_transform("n0b", -1)[1], -1)  # decrement octave
+        self.assertEqual(s.semitone_transform("n1b", -1)[0], "n11")
+        self.assertEqual(s.semitone_transform("n1b", -1)[1], -1)  # decrement octave
+        self.assertEqual(s.semitone_transform("n11x", 1)[0], "n2")
+        self.assertEqual(s.semitone_transform("n11x", 1)[1], 1)  # increment octave
 
-        self.assertEqual(ks._map_to_semitone_range(13, 0)[0], 1)
+        self.assertEqual(s._map_to_semitone_range(13, 0)[0], 1)
 
     def test_invert_even(self):
-        ks = KeySignature(mode="major", key="c")
-        self.assertEqual(ks.invert("f", 5, "c", 5, "even")[0], "g")
-        self.assertEqual(ks.invert("f", 5, "c", 5, "even")[1], 4)
-        self.assertEqual(ks.invert("f", 4, "c", 5, "even")[1], 5)
-        self.assertEqual(ks.invert("d", 5, "c", 5, "even")[0], "a#")
+        s = Scale()
+        self.assertEqual(s.invert("f", 5, "c", 5, "even")[0], "g")
+        self.assertEqual(s.invert("f", 5, "c", 5, "even")[1], 4)
+        self.assertEqual(s.invert("f", 4, "c", 5, "even")[1], 5)
+        self.assertEqual(s.invert("d", 5, "c", 5, "even")[0], "a#")
 
     def test_invert_odd(self):
-        ks = KeySignature(mode="major", key="c")
-        self.assertEqual(ks.invert("f", 5, "c", 5, "odd")[0], "g#")
-        self.assertEqual(ks.invert("d", 5, "c", 5, "odd")[0], "b")
+        s = Scale()
+        self.assertEqual(s.invert("f", 5, "c", 5, "odd")[0], "g#")
+        self.assertEqual(s.invert("d", 5, "c", 5, "odd")[0], "b")
 
     def test_invert_scalar(self):
-        ks = KeySignature(mode="major", key="c")
-        self.assertEqual(ks.invert("f", 5, "c", 5, "scalar")[0], "g")
-        self.assertEqual(ks.invert("d", 5, "c", 5, "scalar")[0], "b")
-        self.assertEqual(ks.invert("g", 5, "c", 5, "scalar")[0], "f")
-        self.assertEqual(ks.invert("b", 5, "c", 5, "scalar")[0], "d")
+        s = Scale()
+        self.assertEqual(s.invert("f", 5, "c", 5, "scalar")[0], "g")
+        self.assertEqual(s.invert("d", 5, "c", 5, "scalar")[0], "b")
+        self.assertEqual(s.invert("g", 5, "c", 5, "scalar")[0], "f")
+        self.assertEqual(s.invert("b", 5, "c", 5, "scalar")[0], "d")
 
     def test_chromatic_key_signature(self):
         ks = KeySignature(mode="chromatic", key="c")
         self.assertEqual(ks.get_mode_length(), 12)
         self.assertEqual(ks.get_number_of_semitones(), 12)
-        self.assertEqual(ks.scalar_transform("c", 2)[0], "d")
-        self.assertEqual(ks.scalar_transform("c#", 2)[0], "d#")
-        self.assertEqual(ks.semitone_transform("c", 2)[0], "d")
-        self.assertEqual(ks.semitone_transform("c#", 2)[0], "d#")
-        self.assertEqual(ks.semitone_transform("b", 1)[0], "c")
-        self.assertEqual(ks._map_to_scalar_range(13, 0)[0], 1)
+        self.assertEqual(ks.scale.scalar_transform("c", 2)[0], "d")
+        self.assertEqual(ks.scale.scalar_transform("c#", 2)[0], "d#")
+        self.assertEqual(ks.scale.semitone_transform("c", 2)[0], "d")
+        self.assertEqual(ks.scale.semitone_transform("c#", 2)[0], "d#")
+        self.assertEqual(ks.scale.semitone_transform("b", 1)[0], "c")
+        self.assertEqual(ks.scale._map_to_scalar_range(13, 0)[0], 1)
 
     def test_third_comma_meantone_key_signature(self):
         t = Temperament(name="third comma meantone")
@@ -337,154 +338,149 @@ class MusicUtilsTestCase(unittest.TestCase):
         self.assertEqual(ks.get_number_of_semitones(), 19)
         self.assertEqual(len(ks.get_notes_in_scale()), 8)
         self.assertEqual(ks.get_notes_in_scale()[7], "n18")
-        self.assertEqual(ks.closest_note("n12")[0], "n11")
-        self.assertEqual(ks.scalar_transform("n5", 2)[0], "n9")
-        self.assertEqual(ks.closest_note("n10#")[0], "n11")
+        self.assertEqual(ks.scale.closest_note("n12")[0], "n11")
+        self.assertEqual(ks.scale.scalar_transform("n5", 2)[0], "n9")
+        self.assertEqual(ks.scale.closest_note("n10#")[0], "n11")
 
     def test_mode_equivalents(self):
         ks = KeySignature(key="e", mode="major")
-        source = ks._scale._normalize_scale(ks.notes_in_scale)
+        source = ks.scale.normalize_scale(ks.notes_in_scale)
         ks = KeySignature(key="db", mode="minor")
-        target = ks._scale._normalize_scale(ks.notes_in_scale)
+        target = ks.scale.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="c#", mode="minor")
-        target = ks._scale._normalize_scale(ks.notes_in_scale)
+        target = ks.scale.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="eb", mode="locrian")
-        target = ks._scale._normalize_scale(ks.notes_in_scale)
+        target = ks.scale.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="d#", mode="locrian")
-        target = ks._scale._normalize_scale(ks.notes_in_scale)
+        target = ks.scale.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="b", mode="mixolydian")
-        target = ks._scale._normalize_scale(ks.notes_in_scale)
+        target = ks.scale.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="a", mode="lydian")
-        target = ks._scale._normalize_scale(ks.notes_in_scale)
+        target = ks.scale.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="g#", mode="phrygian")
-        target = ks._scale._normalize_scale(ks.notes_in_scale)
+        target = ks.scale.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="ab", mode="phrygian")
-        target = ks._scale._normalize_scale(ks.notes_in_scale)
+        target = ks.scale.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="f#", mode="dorian")
-        target = ks._scale._normalize_scale(ks.notes_in_scale)
+        target = ks.scale.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="gb", mode="dorian")
-        target = ks._scale._normalize_scale(ks.notes_in_scale)
+        target = ks.scale.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="e", mode=[2, 2, 1, 2, 2, 2, 1])
-        target = ks._scale._normalize_scale(ks.notes_in_scale)
+        target = ks.scale.normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
 
     def test_solfege_mapper(self):
         ks = KeySignature(key="c", mode="major")
-        self.assertEqual(len(ks._scale.solfege_notes), 8)
+        self.assertEqual(len(ks.scale.solfege_notes), 8)
 
         ks = KeySignature(key="c", mode="major pentatonic")
-        self.assertEqual(len(ks._scale.solfege_notes), 6)
-        self.assertEqual(ks._scale.solfege_notes[2], "me")
-        self.assertEqual(ks._scale.solfege_notes[3], "sol")
+        self.assertEqual(len(ks.scale.solfege_notes), 6)
+        self.assertEqual(ks.scale.solfege_notes[2], "me")
+        self.assertEqual(ks.scale.solfege_notes[3], "sol")
 
         ks = KeySignature(key="c", mode="minor pentatonic")
-        self.assertEqual(len(ks._scale.solfege_notes), 6)
-        self.assertEqual(ks._scale.solfege_notes[2], "fa")
-        self.assertEqual(ks._scale.solfege_notes[3], "sol")
+        self.assertEqual(len(ks.scale.solfege_notes), 6)
+        self.assertEqual(ks.scale.solfege_notes[2], "fa")
+        self.assertEqual(ks.scale.solfege_notes[3], "sol")
 
         ks = KeySignature(key="c", mode="whole tone")
-        self.assertEqual(len(ks._scale.solfege_notes), 7)
-        self.assertEqual(ks._scale.solfege_notes[2], "me")
-        self.assertEqual(ks._scale.solfege_notes[4], "sol")
+        self.assertEqual(len(ks.scale.solfege_notes), 7)
+        self.assertEqual(ks.scale.solfege_notes[2], "me")
+        self.assertEqual(ks.scale.solfege_notes[4], "sol")
 
         ks = KeySignature(key="c", mode="chromatic")
-        self.assertEqual(len(ks._scale.solfege_notes), 13)
-        self.assertEqual(ks._scale.solfege_notes[2], "re")
-        self.assertEqual(ks._scale.solfege_notes[3], "meb")
+        self.assertEqual(len(ks.scale.solfege_notes), 13)
+        self.assertEqual(ks.scale.solfege_notes[2], "re")
+        self.assertEqual(ks.scale.solfege_notes[3], "meb")
 
     def test_convert_to_generic_note_name(self):
-        ks = KeySignature()
-        self.assertEqual(ks._scale.convert_to_generic_note_name("g")[0], "n7")
-        self.assertEqual(ks._scale.convert_to_generic_note_name("sol")[0], "n7")
-        self.assertEqual(ks._scale.convert_to_generic_note_name("5")[0], "n7")
-        self.assertEqual(ks._scale.convert_to_generic_note_name("pa")[0], "n7")
-        self.assertEqual(ks._scale.convert_to_generic_note_name("g#")[0], "n8")
-        self.assertEqual(ks._scale.convert_to_generic_note_name("sol#")[0], "n8")
-        self.assertEqual(ks._scale.convert_to_generic_note_name("5#")[0], "n8")
-        self.assertEqual(ks._scale.convert_to_generic_note_name("pa#")[0], "n8")
+        s = Scale()
+        self.assertEqual(s.convert_to_generic_note_name("g")[0], "n7")
+        self.assertEqual(s.convert_to_generic_note_name("sol")[0], "n7")
+        self.assertEqual(s.convert_to_generic_note_name("5")[0], "n7")
+        self.assertEqual(s.convert_to_generic_note_name("pa")[0], "n7")
+        self.assertEqual(s.convert_to_generic_note_name("g#")[0], "n8")
+        self.assertEqual(s.convert_to_generic_note_name("sol#")[0], "n8")
+        self.assertEqual(s.convert_to_generic_note_name("5#")[0], "n8")
+        self.assertEqual(s.convert_to_generic_note_name("pa#")[0], "n8")
 
-        self.assertEqual(ks._scale.name_converter("sol", ks._scale.solfege_notes), "n7")
-        self.assertEqual(
-            ks._scale.name_converter("pa", ks._scale.east_indian_solfege_notes), "n7"
-        )
+        self.assertEqual(s.name_converter("sol", s.solfege_notes), "n7")
+        self.assertEqual(s.name_converter("pa", s.east_indian_solfege_notes), "n7")
 
-        ks._scale.set_custom_note_names(
+        s.set_custom_note_names(
             ["charlie", "delta", "echo", "foxtrot", "golf", "alfa", "bravo"]
         )
-        self.assertEqual(ks._scale.get_custom_note_names()[4], "golf")
-        self.assertEqual(ks._scale.convert_to_generic_note_name("golf")[0], "n7")
-        self.assertEqual(ks._scale.convert_to_generic_note_name("golf#")[0], "n8")
+        self.assertEqual(s.get_custom_note_names()[4], "golf")
+        self.assertEqual(s.convert_to_generic_note_name("golf")[0], "n7")
+        self.assertEqual(s.convert_to_generic_note_name("golf#")[0], "n8")
 
-        self.assertEqual(ks.semitone_transform("g", 3)[0], "a#")
-        self.assertEqual(ks.semitone_transform("n7", 3)[0], "n10")
-        self.assertEqual(ks.semitone_transform("sol", 3)[0], "tib")
-        self.assertEqual(ks.semitone_transform("5", 3)[0], "7b")
-        self.assertEqual(ks.semitone_transform("pa", 3)[0], "nib")
-        self.assertEqual(ks.semitone_transform("golf", 3)[0], "n10")
+        self.assertEqual(s.semitone_transform("g", 3)[0], "a#")
+        self.assertEqual(s.semitone_transform("n7", 3)[0], "n10")
+        self.assertEqual(s.semitone_transform("sol", 3)[0], "tib")
+        self.assertEqual(s.semitone_transform("5", 3)[0], "7b")
+        self.assertEqual(s.semitone_transform("pa", 3)[0], "nib")
+        self.assertEqual(s.semitone_transform("golf", 3)[0], "n10")
 
     def test_type_conversion(self):
-        ks = KeySignature()
-        ks.set_custom_note_names(
+        s = Scale()
+        s.set_custom_note_names(
             ["charlie", "delta", "echo", "foxtrot", "golf", "alfa", "bravo"]
         )
 
-        self.assertEqual(ks.generic_note_name_convert_to_type("n7", LETTER_NAME), "g")
+        self.assertEqual(s.generic_note_name_convert_to_type("n7", LETTER_NAME), "g")
+        self.assertEqual(s.generic_note_name_convert_to_type("n7", SOLFEGE_NAME), "sol")
         self.assertEqual(
-            ks.generic_note_name_convert_to_type("n7", SOLFEGE_NAME), "sol"
+            s.generic_note_name_convert_to_type("n8", SOLFEGE_NAME), "sol#"
+        )
+        self.assertEqual(s.generic_note_name_convert_to_type("n9", SOLFEGE_NAME), "la")
+        self.assertEqual(
+            s.generic_note_name_convert_to_type("n7", EAST_INDIAN_SOLFEGE_NAME),
+            "pa",
         )
         self.assertEqual(
-            ks.generic_note_name_convert_to_type("n8", SOLFEGE_NAME), "sol#"
+            s.generic_note_name_convert_to_type("n7", SCALAR_MODE_NUMBER), "5"
         )
-        self.assertEqual(ks.generic_note_name_convert_to_type("n9", SOLFEGE_NAME), "la")
-        self.assertEqual(
-            ks.generic_note_name_convert_to_type("n7", EAST_INDIAN_SOLFEGE_NAME), "pa"
-        )
-        self.assertEqual(
-            ks.generic_note_name_convert_to_type("n7", SCALAR_MODE_NUMBER), "5"
-        )
-        self.assertEqual(
-            ks.generic_note_name_convert_to_type("n7", CUSTOM_NAME), "golf"
-        )
+        self.assertEqual(s.generic_note_name_convert_to_type("n7", CUSTOM_NAME), "golf")
 
     def test_restore_format(self):
-        ks = KeySignature()
-        self.assertEqual(ks._restore_format("n7", SOLFEGE_NAME, True), "sol")
-        self.assertEqual(ks._restore_format("n8", SOLFEGE_NAME, True), "sol#")
-        self.assertEqual(ks._restore_format("n8", SOLFEGE_NAME, False), "lab")
+        s = Scale()
+        self.assertEqual(s._restore_format("n7", SOLFEGE_NAME, True), "sol")
+        self.assertEqual(s._restore_format("n8", SOLFEGE_NAME, True), "sol#")
+        self.assertEqual(s._restore_format("n8", SOLFEGE_NAME, False), "lab")
 
-        self.assertEqual(ks._pitch_to_note_number("a", 4), 57)
+        self.assertEqual(s._pitch_to_note_number("a", 4), 57)
 
         # Modal pitch starts at 0
-        self.assertEqual(ks.modal_pitch_to_letter(4)[0], "g")
+        self.assertEqual(s.modal_pitch_to_letter(4)[0], "g")
 
     def test_pitch_type_check(self):
-        ks = KeySignature()
-        ks._scale.set_custom_note_names(
+        s = Scale()
+        s.set_custom_note_names(
             ["charlie", "delta", "echo", "foxtrot", "golf", "alfa", "bravo"]
         )
 
-        self.assertEqual(ks._scale.pitch_name_type("g"), LETTER_NAME)
-        self.assertEqual(ks._scale.pitch_name_type("c#"), LETTER_NAME)
-        self.assertEqual(ks._scale.pitch_name_type("n7"), GENERIC_NOTE_NAME)
-        self.assertEqual(ks._scale.pitch_name_type("n7b"), GENERIC_NOTE_NAME)
-        self.assertEqual(ks._scale.pitch_name_type("sol"), SOLFEGE_NAME)
-        self.assertEqual(ks._scale.pitch_name_type("sol#"), SOLFEGE_NAME)
-        self.assertEqual(ks._scale.pitch_name_type("pa"), EAST_INDIAN_SOLFEGE_NAME)
-        self.assertEqual(ks._scale.pitch_name_type("5"), SCALAR_MODE_NUMBER)
-        self.assertEqual(ks._scale.pitch_name_type("golf"), CUSTOM_NAME)
-        self.assertEqual(ks._generic_note_name_to_custom_note_name("n7")[0], "golf")
+        self.assertEqual(s.pitch_name_type("g"), LETTER_NAME)
+        self.assertEqual(s.pitch_name_type("c#"), LETTER_NAME)
+        self.assertEqual(s.pitch_name_type("n7"), GENERIC_NOTE_NAME)
+        self.assertEqual(s.pitch_name_type("n7b"), GENERIC_NOTE_NAME)
+        self.assertEqual(s.pitch_name_type("sol"), SOLFEGE_NAME)
+        self.assertEqual(s.pitch_name_type("sol#"), SOLFEGE_NAME)
+        self.assertEqual(s.pitch_name_type("pa"), EAST_INDIAN_SOLFEGE_NAME)
+        self.assertEqual(s.pitch_name_type("5"), SCALAR_MODE_NUMBER)
+        self.assertEqual(s.pitch_name_type("golf"), CUSTOM_NAME)
+        self.assertEqual(s._generic_note_name_to_custom_note_name("n7")[0], "golf")
+        self.assertEqual(s.pitch_name_type("foobar"), UNKNOWN_PITCH_NAME)
 
-        self.assertEqual(ks._scale.pitch_name_type("foobar"), UNKNOWN_PITCH_NAME)
         self.assertEqual(get_pitch_type("g"), LETTER_NAME)
         self.assertEqual(get_pitch_type("c#"), LETTER_NAME)
         self.assertEqual(get_pitch_type("n7"), GENERIC_NOTE_NAME)
@@ -498,36 +494,40 @@ class MusicUtilsTestCase(unittest.TestCase):
     def test_fixed_solfege(self):
         ks = KeySignature(key="g", mode="major")
         self.assertEqual(
-            ks.generic_note_name_convert_to_type("n7", SOLFEGE_NAME), "sol"
+            ks.scale.generic_note_name_convert_to_type("n7", SOLFEGE_NAME), "sol"
         )
-        self.assertEqual(ks._scale.convert_to_generic_note_name("sol")[0], "n7")
-        ks.set_fixed_solfege(True)
-        self.assertTrue(ks.get_fixed_solfege())
+        self.assertEqual(ks.scale.convert_to_generic_note_name("sol")[0], "n7")
+        ks.scale.set_fixed_solfege(True)
+        self.assertTrue(ks.scale.get_fixed_solfege())
 
-        self.assertEqual(ks.generic_note_name_convert_to_type("n7", SOLFEGE_NAME), "do")
         self.assertEqual(
-            ks._scale.convert_to_generic_note_name("do", fixed_solfege=True)[0], "n7"
+            ks.scale.generic_note_name_convert_to_type("n7", SOLFEGE_NAME), "do"
         )
+        self.assertEqual(ks.scale.convert_to_generic_note_name("do")[0], "n7")
         self.assertEqual(
-            ks._generic_note_name_to_letter_name("n6", prefer_sharps=True)[0],
+            ks.scale._generic_note_name_to_letter_name("n6", prefer_sharps=True)[0],
             "f#",
         )
         self.assertEqual(
-            ks._generic_note_name_to_solfege("n6", prefer_sharps=True)[0], "ti"
+            ks.scale._generic_note_name_to_solfege("n6", prefer_sharps=True)[0], "ti"
         )
         self.assertEqual(
-            ks._convert_from_note_name("n7", ks._scale.solfege_notes)[0], "do"
+            ks.scale._convert_from_note_name("n7", ks.scale.solfege_notes)[0], "do"
         )
-        self.assertEqual(ks._generic_note_name_to_east_indian_solfege("n7")[0], "sa")
-        self.assertEqual(ks._generic_note_name_to_scalar_mode_number("n7")[0], "1")
+        self.assertEqual(
+            ks.scale._generic_note_name_to_east_indian_solfege("n7")[0], "sa"
+        )
+        self.assertEqual(
+            ks.scale._generic_note_name_to_scalar_mode_number("n7")[0], "1"
+        )
 
     def test_get_frequency(self):
         t = Temperament()
-        ks = KeySignature()
+        s = Scale()
         self.assertEqual(
             int(
                 t.get_freq_by_generic_note_name_and_octave(
-                    ks._scale.convert_to_generic_note_name("a")[0], 4
+                    s.convert_to_generic_note_name("a")[0], 4
                 )
                 + 0.5
             ),
@@ -536,15 +536,15 @@ class MusicUtilsTestCase(unittest.TestCase):
 
     def test_frequency_conversion(self):
         t = Temperament()
-        ks = KeySignature()
-        ks._scale.set_custom_note_names(
+        s = Scale()
+        s.set_custom_note_names(
             ["charlie", "delta", "echo", "foxtrot", "golf", "alfa", "bravo"]
         )
 
         self.assertEqual(
             round(
                 t.get_freq_by_generic_note_name_and_octave(
-                    ks._scale.convert_to_generic_note_name("g")[0], 4
+                    s.convert_to_generic_note_name("g")[0], 4
                 ),
                 100,
             ),
@@ -553,7 +553,7 @@ class MusicUtilsTestCase(unittest.TestCase):
         self.assertEqual(
             round(
                 t.get_freq_by_generic_note_name_and_octave(
-                    ks._scale.convert_to_generic_note_name("sol")[0], 4
+                    s.convert_to_generic_note_name("sol")[0], 4
                 ),
                 100,
             ),
@@ -562,7 +562,7 @@ class MusicUtilsTestCase(unittest.TestCase):
         self.assertEqual(
             round(
                 t.get_freq_by_generic_note_name_and_octave(
-                    ks._scale.convert_to_generic_note_name("5")[0], 4
+                    s.convert_to_generic_note_name("5")[0], 4
                 ),
                 100,
             ),
@@ -571,7 +571,7 @@ class MusicUtilsTestCase(unittest.TestCase):
         self.assertEqual(
             round(
                 t.get_freq_by_generic_note_name_and_octave(
-                    ks._scale.convert_to_generic_note_name("pa")[0], 4
+                    s.convert_to_generic_note_name("pa")[0], 4
                 ),
                 100,
             ),
@@ -580,7 +580,7 @@ class MusicUtilsTestCase(unittest.TestCase):
         self.assertEqual(
             round(
                 t.get_freq_by_generic_note_name_and_octave(
-                    ks._scale.convert_to_generic_note_name("golf")[0], 4
+                    s.convert_to_generic_note_name("golf")[0], 4
                 ),
                 100,
             ),
@@ -591,23 +591,23 @@ class MusicUtilsTestCase(unittest.TestCase):
         ks = KeySignature(mode=[], number_of_semitones=21)
         self.assertEqual(ks.get_mode_length(), 21)
         self.assertEqual(ks.get_number_of_semitones(), 21)
-        self.assertEqual(ks.closest_note("cb")[0], "cb")
-        self.assertEqual(ks.semitone_transform("gb", 1)[0], "g")
-        self.assertEqual(ks.semitone_transform("cb", 3)[0], "d")
-        self.assertEqual(ks.semitone_transform("c", -3)[0], "bb")
+        self.assertEqual(ks.scale.closest_note("cb")[0], "cb")
+        self.assertEqual(ks.scale.semitone_transform("gb", 1)[0], "g")
+        self.assertEqual(ks.scale.semitone_transform("cb", 3)[0], "d")
+        self.assertEqual(ks.scale.semitone_transform("c", -3)[0], "bb")
         ks = KeySignature(mode=[3, 3, 3, 3, 3, 3, 3], number_of_semitones=21)
-        self.assertEqual(ks.closest_note("cb")[0], "c")
-        self.assertEqual(ks.closest_note("db")[0], "d")
-        self.assertEqual(ks.closest_note("c#")[0], "c")
-        self.assertEqual(ks.scalar_transform("c", 1)[0], "d")
+        self.assertEqual(ks.scale.closest_note("cb")[0], "c")
+        self.assertEqual(ks.scale.closest_note("db")[0], "d")
+        self.assertEqual(ks.scale.closest_note("c#")[0], "c")
+        self.assertEqual(ks.scale.scalar_transform("c", 1)[0], "d")
         ks = KeySignature(number_of_semitones=21)
-        self.assertEqual(ks.closest_note("cb")[0], "c")
-        self.assertEqual(ks.closest_note("db")[0], "d")
-        self.assertEqual(ks.closest_note("c#")[0], "c")
-        self.assertEqual(ks.scalar_transform("c", 1)[0], "d")
+        self.assertEqual(ks.scale.closest_note("cb")[0], "c")
+        self.assertEqual(ks.scale.closest_note("db")[0], "d")
+        self.assertEqual(ks.scale.closest_note("c#")[0], "c")
+        self.assertEqual(ks.scale.scalar_transform("c", 1)[0], "d")
         ks = KeySignature(key="bb", mode="lydian", number_of_semitones=21)
-        self.assertEqual(ks.closest_note("bb")[0], "bb")
-        self.assertEqual(ks.closest_note("n18")[0], "n17")
+        self.assertEqual(ks.scale.closest_note("bb")[0], "bb")
+        self.assertEqual(ks.scale.closest_note("n18")[0], "n17")
 
     def print_scales(self):
         ks = KeySignature(key="c", mode="ionian")

--- a/src/musicUtils/.archive/musicutils_unittest.py
+++ b/src/musicUtils/.archive/musicutils_unittest.py
@@ -25,14 +25,11 @@ from musicutils import (
     SHARP,
     GENERIC_NOTE_NAME,
     LETTER_NAME,
-    SOLFEGE_NAME,
-    EAST_INDIAN_SOLFEGE_NAME,
-    SCALAR_MODE_NUMBER,
     CUSTOM_NAME,
     UNKNOWN_PITCH_NAME,
-    SOLFEGE_NAMES,
-    EAST_INDIAN_NAMES,
-    SCALAR_MODE_NUMBERS,
+    SOLFEGE_NAME,
+    EAST_INDIAN_SOLFEGE_NAME,
+    SCALAR_MODE_NUMBER
 )
 
 
@@ -173,7 +170,7 @@ class MusicUtilsTestCase(unittest.TestCase):
 
     def test_normalize_scale(self):
         ks = KeySignature()
-        normalized_scale = ks.normalize_scale(
+        normalized_scale = ks._scale._normalize_scale(
             ["c", "cx", "fbb", "f", "g", "a", "b", "c"]
         )
         self.assertEqual(normalized_scale[1], "d")
@@ -333,98 +330,100 @@ class MusicUtilsTestCase(unittest.TestCase):
         t = Temperament(name="third comma meantone")
         ks = KeySignature(
             key="n0",
-            # number_of_semitones=t.get_number_of_semitones_in_octave(),
+            number_of_semitones=t.get_number_of_semitones_in_octave(),
             mode=[2, 2, 1, 2, 2, 2, 7, 1],
         )
         self.assertEqual(ks.get_mode_length(), 8)
         self.assertEqual(ks.get_number_of_semitones(), 19)
-        self.assertEqual(len(ks.get_scale()), 8)
-        self.assertEqual(ks.get_scale()[7], "n18")
+        self.assertEqual(len(ks.get_notes_in_scale()), 8)
+        self.assertEqual(ks.get_notes_in_scale()[7], "n18")
         self.assertEqual(ks.closest_note("n12")[0], "n11")
         self.assertEqual(ks.scalar_transform("n5", 2)[0], "n9")
         self.assertEqual(ks.closest_note("n10#")[0], "n11")
 
     def test_mode_equivalents(self):
         ks = KeySignature(key="e", mode="major")
-        source = ks.normalize_scale(ks.scale)
+        source = ks._scale._normalize_scale(ks.notes_in_scale)
         ks = KeySignature(key="db", mode="minor")
-        target = ks.normalize_scale(ks.scale)
+        target = ks._scale._normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="c#", mode="minor")
-        target = ks.normalize_scale(ks.scale)
+        target = ks._scale._normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="eb", mode="locrian")
-        target = ks.normalize_scale(ks.scale)
+        target = ks._scale._normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="d#", mode="locrian")
-        target = ks.normalize_scale(ks.scale)
+        target = ks._scale._normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="b", mode="mixolydian")
-        target = ks.normalize_scale(ks.scale)
+        target = ks._scale._normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="a", mode="lydian")
-        target = ks.normalize_scale(ks.scale)
+        target = ks._scale._normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="g#", mode="phrygian")
-        target = ks.normalize_scale(ks.scale)
+        target = ks._scale._normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="ab", mode="phrygian")
-        target = ks.normalize_scale(ks.scale)
+        target = ks._scale._normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="f#", mode="dorian")
-        target = ks.normalize_scale(ks.scale)
+        target = ks._scale._normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="gb", mode="dorian")
-        target = ks.normalize_scale(ks.scale)
+        target = ks._scale._normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
         ks = KeySignature(key="e", mode=[2, 2, 1, 2, 2, 2, 1])
-        target = ks.normalize_scale(ks.scale)
+        target = ks._scale._normalize_scale(ks.notes_in_scale)
         self.assertTrue(compare_scales(source, target))
 
     def test_solfege_mapper(self):
         ks = KeySignature(key="c", mode="major")
-        self.assertEqual(len(ks.solfege_notes), 8)
+        self.assertEqual(len(ks._scale.solfege_notes), 8)
 
         ks = KeySignature(key="c", mode="major pentatonic")
-        self.assertEqual(len(ks.solfege_notes), 6)
-        self.assertEqual(ks.solfege_notes[2], "me")
-        self.assertEqual(ks.solfege_notes[3], "sol")
+        self.assertEqual(len(ks._scale.solfege_notes), 6)
+        self.assertEqual(ks._scale.solfege_notes[2], "me")
+        self.assertEqual(ks._scale.solfege_notes[3], "sol")
 
         ks = KeySignature(key="c", mode="minor pentatonic")
-        self.assertEqual(len(ks.solfege_notes), 6)
-        self.assertEqual(ks.solfege_notes[2], "fa")
-        self.assertEqual(ks.solfege_notes[3], "sol")
+        self.assertEqual(len(ks._scale.solfege_notes), 6)
+        self.assertEqual(ks._scale.solfege_notes[2], "fa")
+        self.assertEqual(ks._scale.solfege_notes[3], "sol")
 
         ks = KeySignature(key="c", mode="whole tone")
-        self.assertEqual(len(ks.solfege_notes), 7)
-        self.assertEqual(ks.solfege_notes[2], "me")
-        self.assertEqual(ks.solfege_notes[4], "sol")
+        self.assertEqual(len(ks._scale.solfege_notes), 7)
+        self.assertEqual(ks._scale.solfege_notes[2], "me")
+        self.assertEqual(ks._scale.solfege_notes[4], "sol")
 
         ks = KeySignature(key="c", mode="chromatic")
-        self.assertEqual(len(ks.solfege_notes), 13)
-        self.assertEqual(ks.solfege_notes[2], "re")
-        self.assertEqual(ks.solfege_notes[3], "meb")
+        self.assertEqual(len(ks._scale.solfege_notes), 13)
+        self.assertEqual(ks._scale.solfege_notes[2], "re")
+        self.assertEqual(ks._scale.solfege_notes[3], "meb")
 
     def test_convert_to_generic_note_name(self):
         ks = KeySignature()
-        self.assertEqual(ks.convert_to_generic_note_name("g")[0], "n7")
-        self.assertEqual(ks.convert_to_generic_note_name("sol")[0], "n7")
-        self.assertEqual(ks.convert_to_generic_note_name("5")[0], "n7")
-        self.assertEqual(ks.convert_to_generic_note_name("pa")[0], "n7")
-        self.assertEqual(ks.convert_to_generic_note_name("g#")[0], "n8")
-        self.assertEqual(ks.convert_to_generic_note_name("sol#")[0], "n8")
-        self.assertEqual(ks.convert_to_generic_note_name("5#")[0], "n8")
-        self.assertEqual(ks.convert_to_generic_note_name("pa#")[0], "n8")
+        self.assertEqual(ks._scale.convert_to_generic_note_name("g")[0], "n7")
+        self.assertEqual(ks._scale.convert_to_generic_note_name("sol")[0], "n7")
+        self.assertEqual(ks._scale.convert_to_generic_note_name("5")[0], "n7")
+        self.assertEqual(ks._scale.convert_to_generic_note_name("pa")[0], "n7")
+        self.assertEqual(ks._scale.convert_to_generic_note_name("g#")[0], "n8")
+        self.assertEqual(ks._scale.convert_to_generic_note_name("sol#")[0], "n8")
+        self.assertEqual(ks._scale.convert_to_generic_note_name("5#")[0], "n8")
+        self.assertEqual(ks._scale.convert_to_generic_note_name("pa#")[0], "n8")
 
-        self.assertEqual(ks._name_converter("sol", ks.solfege_notes), "n7")
-        self.assertEqual(ks._name_converter("pa", ks.east_indian_solfege_notes), "n7")
+        self.assertEqual(ks._scale.name_converter("sol", ks._scale.solfege_notes), "n7")
+        self.assertEqual(
+            ks._scale.name_converter("pa", ks._scale.east_indian_solfege_notes), "n7"
+        )
 
-        ks.set_custom_note_names(
+        ks._scale.set_custom_note_names(
             ["charlie", "delta", "echo", "foxtrot", "golf", "alfa", "bravo"]
         )
-        self.assertEqual(ks.get_custom_note_names()[4], "golf")
-        self.assertEqual(ks.convert_to_generic_note_name("golf")[0], "n7")
-        self.assertEqual(ks.convert_to_generic_note_name("golf#")[0], "n8")
+        self.assertEqual(ks._scale.get_custom_note_names()[4], "golf")
+        self.assertEqual(ks._scale.convert_to_generic_note_name("golf")[0], "n7")
+        self.assertEqual(ks._scale.convert_to_generic_note_name("golf#")[0], "n8")
 
         self.assertEqual(ks.semitone_transform("g", 3)[0], "a#")
         self.assertEqual(ks.semitone_transform("n7", 3)[0], "n10")
@@ -438,18 +437,6 @@ class MusicUtilsTestCase(unittest.TestCase):
         ks.set_custom_note_names(
             ["charlie", "delta", "echo", "foxtrot", "golf", "alfa", "bravo"]
         )
-
-        self.assertEqual(ks._mode_map_list(SOLFEGE_NAMES)[4], "sol")
-        ks._assign_solfege_note_names()
-        self.assertEqual(ks.solfege_notes[4], "sol")
-
-        self.assertEqual(ks._mode_map_list(EAST_INDIAN_NAMES)[4], "pa")
-        ks._assign_east_indian_solfege_note_names()
-        self.assertEqual(ks.east_indian_solfege_notes[4], "pa")
-
-        self.assertEqual(ks._mode_map_list(SCALAR_MODE_NUMBERS)[4], "5")
-        ks._assign_scalar_mode_numbers()
-        self.assertEqual(ks.scalar_mode_numbers[4], "5")
 
         self.assertEqual(ks.generic_note_name_convert_to_type("n7", LETTER_NAME), "g")
         self.assertEqual(
@@ -482,22 +469,22 @@ class MusicUtilsTestCase(unittest.TestCase):
 
     def test_pitch_type_check(self):
         ks = KeySignature()
-        ks.set_custom_note_names(
+        ks._scale.set_custom_note_names(
             ["charlie", "delta", "echo", "foxtrot", "golf", "alfa", "bravo"]
         )
 
-        self.assertEqual(ks.pitch_name_type("g"), LETTER_NAME)
-        self.assertEqual(ks.pitch_name_type("c#"), LETTER_NAME)
-        self.assertEqual(ks.pitch_name_type("n7"), GENERIC_NOTE_NAME)
-        self.assertEqual(ks.pitch_name_type("n7b"), GENERIC_NOTE_NAME)
-        self.assertEqual(ks.pitch_name_type("sol"), SOLFEGE_NAME)
-        self.assertEqual(ks.pitch_name_type("sol#"), SOLFEGE_NAME)
-        self.assertEqual(ks.pitch_name_type("pa"), EAST_INDIAN_SOLFEGE_NAME)
-        self.assertEqual(ks.pitch_name_type("5"), SCALAR_MODE_NUMBER)
-        self.assertEqual(ks.pitch_name_type("golf"), CUSTOM_NAME)
+        self.assertEqual(ks._scale.pitch_name_type("g"), LETTER_NAME)
+        self.assertEqual(ks._scale.pitch_name_type("c#"), LETTER_NAME)
+        self.assertEqual(ks._scale.pitch_name_type("n7"), GENERIC_NOTE_NAME)
+        self.assertEqual(ks._scale.pitch_name_type("n7b"), GENERIC_NOTE_NAME)
+        self.assertEqual(ks._scale.pitch_name_type("sol"), SOLFEGE_NAME)
+        self.assertEqual(ks._scale.pitch_name_type("sol#"), SOLFEGE_NAME)
+        self.assertEqual(ks._scale.pitch_name_type("pa"), EAST_INDIAN_SOLFEGE_NAME)
+        self.assertEqual(ks._scale.pitch_name_type("5"), SCALAR_MODE_NUMBER)
+        self.assertEqual(ks._scale.pitch_name_type("golf"), CUSTOM_NAME)
         self.assertEqual(ks._generic_note_name_to_custom_note_name("n7")[0], "golf")
 
-        self.assertEqual(ks.pitch_name_type("foobar"), UNKNOWN_PITCH_NAME)
+        self.assertEqual(ks._scale.pitch_name_type("foobar"), UNKNOWN_PITCH_NAME)
         self.assertEqual(get_pitch_type("g"), LETTER_NAME)
         self.assertEqual(get_pitch_type("c#"), LETTER_NAME)
         self.assertEqual(get_pitch_type("n7"), GENERIC_NOTE_NAME)
@@ -513,19 +500,24 @@ class MusicUtilsTestCase(unittest.TestCase):
         self.assertEqual(
             ks.generic_note_name_convert_to_type("n7", SOLFEGE_NAME), "sol"
         )
-        self.assertEqual(ks.convert_to_generic_note_name("sol")[0], "n7")
+        self.assertEqual(ks._scale.convert_to_generic_note_name("sol")[0], "n7")
         ks.set_fixed_solfege(True)
         self.assertTrue(ks.get_fixed_solfege())
 
         self.assertEqual(ks.generic_note_name_convert_to_type("n7", SOLFEGE_NAME), "do")
-        self.assertEqual(ks.convert_to_generic_note_name("do")[0], "n7")
         self.assertEqual(
-            ks._generic_note_name_to_letter_name("n6", prefer_sharps=True)[0], "f#"
+            ks._scale.convert_to_generic_note_name("do", fixed_solfege=True)[0], "n7"
+        )
+        self.assertEqual(
+            ks._generic_note_name_to_letter_name("n6", prefer_sharps=True)[0],
+            "f#",
         )
         self.assertEqual(
             ks._generic_note_name_to_solfege("n6", prefer_sharps=True)[0], "ti"
         )
-        self.assertEqual(ks._convert_from_note_name("n7", ks.solfege_notes)[0], "do")
+        self.assertEqual(
+            ks._convert_from_note_name("n7", ks._scale.solfege_notes)[0], "do"
+        )
         self.assertEqual(ks._generic_note_name_to_east_indian_solfege("n7")[0], "sa")
         self.assertEqual(ks._generic_note_name_to_scalar_mode_number("n7")[0], "1")
 
@@ -535,64 +527,64 @@ class MusicUtilsTestCase(unittest.TestCase):
         self.assertEqual(
             int(
                 t.get_freq_by_generic_note_name_and_octave(
-                    ks.convert_to_generic_note_name("a")[0], 4
+                    ks._scale.convert_to_generic_note_name("a")[0], 4
                 )
                 + 0.5
             ),
-            440
+            440,
         )
 
     def test_frequency_conversion(self):
         t = Temperament()
         ks = KeySignature()
-        ks.set_custom_note_names(
+        ks._scale.set_custom_note_names(
             ["charlie", "delta", "echo", "foxtrot", "golf", "alfa", "bravo"]
         )
 
         self.assertEqual(
             round(
                 t.get_freq_by_generic_note_name_and_octave(
-                    ks.convert_to_generic_note_name("g")[0], 4
+                    ks._scale.convert_to_generic_note_name("g")[0], 4
                 ),
                 100,
             ),
-            392.0
+            392.0,
         )
         self.assertEqual(
             round(
                 t.get_freq_by_generic_note_name_and_octave(
-                    ks.convert_to_generic_note_name("sol")[0], 4
+                    ks._scale.convert_to_generic_note_name("sol")[0], 4
                 ),
                 100,
             ),
-            392.0
+            392.0,
         )
         self.assertEqual(
             round(
                 t.get_freq_by_generic_note_name_and_octave(
-                    ks.convert_to_generic_note_name("5")[0], 4
+                    ks._scale.convert_to_generic_note_name("5")[0], 4
                 ),
                 100,
             ),
-            392.0
+            392.0,
         )
         self.assertEqual(
             round(
                 t.get_freq_by_generic_note_name_and_octave(
-                    ks.convert_to_generic_note_name("pa")[0], 4
+                    ks._scale.convert_to_generic_note_name("pa")[0], 4
                 ),
                 100,
             ),
-            392.0
+            392.0,
         )
         self.assertEqual(
             round(
                 t.get_freq_by_generic_note_name_and_octave(
-                    ks.convert_to_generic_note_name("golf")[0], 4
+                    ks._scale.convert_to_generic_note_name("golf")[0], 4
                 ),
                 100,
             ),
-            392.0
+            392.0,
         )
 
     def test_meantone_scales(self):

--- a/src/musicUtils/.archive/scale.py
+++ b/src/musicUtils/.archive/scale.py
@@ -14,6 +14,44 @@ The Scale class defines an object that manages the notes in a scale
 # License along with this library; if not, write to the Free Software
 # Foundation, 51 Franklin Street, Suite 500 Boston, MA 02110-1335 USA
 
+from musicutils import (
+    normalize_pitch,
+    strip_accidental,
+    get_pitch_type,
+    is_a_sharp,
+    is_a_flat,
+    find_sharp_index,
+    find_flat_index,
+)
+
+from musicutils import (
+    CHROMATIC_NOTES_SHARP,
+    CHROMATIC_NOTES_FLAT,
+    ALL_NOTES,
+    LETTER_NAME,
+    SOLFEGE_NAME,
+    SOLFEGE_SHARP,
+    SOLFEGE_FLAT,
+    SOLFEGE_NAMES,
+    EAST_INDIAN_SOLFEGE_NAME,
+    EAST_INDIAN_SHARP,
+    EAST_INDIAN_FLAT,
+    EAST_INDIAN_NAMES,
+    SCALAR_MODE_NUMBER,
+    SCALAR_MODE_NUMBERS,
+    SCALAR_NAMES_SHARP,
+    SCALAR_NAMES_FLAT,
+    EQUIVALENTS,
+    EQUIVALENT_SHARPS,
+    EQUIVALENT_FLATS,
+    PITCH_LETTERS,
+    CONVERT_DOWN,
+    CONVERT_UP,
+    GENERIC_NOTE_NAME,
+    UNKNOWN_PITCH_NAME,
+    CUSTOM_NAME,
+)
+
 
 class Scale:
     """
@@ -41,6 +79,7 @@ class Scale:
         starting_index=0,
         number_of_semitones=12,
         prefer_sharps=True,
+        key="c",
     ):
         """
         When defining a scale, we need the half steps pattern that defines
@@ -65,8 +104,12 @@ class Scale:
         prefer_sharps : boolean
             If we are mapping from 12 to 21 semitones, we need to know
             whether or not to prefer sharps or flats.
-        """
 
+        key : str
+            Key designate for the scale.
+        """
+        self.key = key
+        self.prefer_sharps = prefer_sharps
         # Calculate the number of semitones by summing up the half
         # steps.
         if half_steps_pattern is None:
@@ -103,7 +146,7 @@ class Scale:
             self.number_of_semitones != number_of_semitones
             and number_of_semitones == 21
         ):
-            if prefer_sharps:
+            if self.prefer_sharps:
                 j = 0
             else:
                 j = 1
@@ -114,6 +157,197 @@ class Scale:
             self.note_names = []
             for i in range(self.number_of_semitones):
                 self.note_names.append("n%d" % i)
+
+        self.generic_names = self.get_scale()
+        if self.number_of_semitones == 12:
+            if self.prefer_sharps:
+                self.letter_names = self.get_scale(pitch_format=CHROMATIC_NOTES_SHARP)
+            else:
+                self.letter_names = self.get_scale(pitch_format=CHROMATIC_NOTES_FLAT)
+        elif self.number_of_semitones == 21:
+            self.letter_names = self.get_scale(pitch_format=ALL_NOTES)
+        else:
+            # At some point we may want to add some additional
+            # notation, ^ and v, for 41.
+            self.letter_names = None
+
+        self.solfege_notes = []
+        self.east_indian_solfege_notes = []
+        self.scalar_mode_numbers = []
+        self.custom_note_names = []
+
+        if self.number_of_semitones == 12:
+            self.letter_names = self._normalize_scale(self.letter_names)[:]
+            self._assign_solfege_note_names()
+            self._assign_east_indian_solfege_note_names()
+            self._assign_scalar_mode_numbers()
+
+    def _normalize_scale(self, scale):
+        """
+        Normalize the letter names by converting double sharps and double
+        flats.
+        """
+        # Force the first note to be the same designation as the key.
+        scale[0] = self.key
+        scale[-1] = self.key
+        # At this point, the scale includes the first note of the next
+        # octave. Hence, for example, the Latin modes have 8 notes.
+        if len(scale) < 9:
+            # Convert to preferred accidental.
+            if not self.prefer_sharps and "#" in self.key:
+                for i, note in enumerate(scale):
+                    if "b" in note:
+                        if note in EQUIVALENT_SHARPS:
+                            scale[i] = EQUIVALENT_SHARPS[note]
+
+            # For Latin scales, we cannot skip notes.
+            if len(scale) == 8:
+                for i in range(len(scale) - 1):
+                    idx1 = PITCH_LETTERS.index(scale[i][0])
+                    idx2 = PITCH_LETTERS.index(scale[i + 1][0])
+                    if idx2 < idx1:
+                        idx2 += 7
+                    if idx2 - idx1 > 1:
+                        if scale[i + 1] in CONVERT_DOWN:
+                            scale[i + 1] = CONVERT_DOWN[scale[i + 1]]
+            # And ensure there are no repeated letter names.
+            for i in range(len(scale) - 1):
+                if i == 0 and scale[i][0] == scale[i + 1][0]:
+                    if scale[i + 1] in CONVERT_UP:
+                        new_next_note = CONVERT_UP[scale[i + 1]]
+                        scale[i + 1] = new_next_note
+                elif scale[i][0] == scale[i + 1][0]:
+                    if scale[i] in CONVERT_DOWN:
+                        new_current_note = CONVERT_DOWN[scale[i]]
+                    else:
+                        print(scale[i])
+                    # If changing the current note makes it the same
+                    # as the previous note, then we need to change the
+                    # next note instead.
+                    if new_current_note[0] != scale[i - 1][0]:
+                        scale[i] = new_current_note
+                    else:
+                        if scale[i + 1] in CONVERT_UP:
+                            new_next_note = CONVERT_UP[scale[i + 1]]
+                            scale[i + 1] = new_next_note
+        else:
+            # Convert to preferred accidental.
+            if "#" in self.key:
+                for i, note in enumerate(scale):
+                    if "b" in note:
+                        if note in EQUIVALENT_SHARPS:
+                            scale[i] = EQUIVALENT_SHARPS[note]
+
+        convert_up = False
+        convert_down = False
+        for i, note in enumerate(scale):
+            if "x" in note:
+                convert_up = True
+                break
+            if len(scale[i]) > 2:
+                convert_down = True
+        if convert_up:
+            for i, note in enumerate(scale):
+                if "x" in note:
+                    scale[i] = CONVERT_UP[note]
+                if scale[i] in EQUIVALENT_FLATS:
+                    scale[i] = EQUIVALENT_FLATS[scale[i]]
+        elif convert_down:
+            for i, note in enumerate(scale):
+                if len(note) > 2:
+                    scale[i] = CONVERT_DOWN[note]
+                if note in EQUIVALENT_SHARPS:
+                    scale[i] = EQUIVALENT_SHARPS[scale[i]]
+
+        return scale
+
+    def _mode_map_list(self, source_list):
+        """
+        Given a list of names, map them to the current mode.
+
+        Parameters
+        ----------
+        source_list : list
+            List of names, e.g., Solfege names
+
+        Returns
+        -------
+        list
+            List of names mapped to the mode
+        """
+        return_list = []
+        # Don't include the octave note.
+        mode_length = len(self.letter_names) - 1
+        offset = "cdefgab".index(self.letter_names[0][0])
+        for i in range(len(self.letter_names)):
+            j = "cdefgab".index(self.letter_names[i][0]) - offset
+            if j < 0:
+                j += len(source_list)
+            if mode_length < 8:
+                # We ensured a unique letter name for each note when we
+                # built the scale.
+                return_list.append(source_list[j])
+            else:
+                # Some letters are repeated, so we need the accidentals.
+                return_list.append(
+                    source_list[j]
+                    + ["bb", "b", "", "#", "x"][
+                        strip_accidental(self.letter_names[i])[1] + 2
+                    ]
+                )
+        return_list[-1] = return_list[0]
+        return return_list
+
+    def _assign_solfege_note_names(self):
+        """
+        Create a Solfege mapping of the scale ("fixed Solfege == True")
+
+        Examples:
+        Major: ['do', 're', 'me', 'fa', 'sol', 'la', 'ti', 'do']
+        Major Pentatonic: ['do', 're', 'me', 'sol', 'la', 'do']
+        Minor Pentatonic: ['do', 'me', 'fa', 'sol', 'ti', 'do']
+        Whole Tone: ['do', 're', 'me', 'sol', 'la', 'ti', 'do']
+        NOTE: Solfege assignment only works for temperaments of 12 semitones.
+        """
+        self.solfege_notes = []
+
+        if self.number_of_semitones == 12 or self.number_of_semitones == 21:
+            self.solfege_notes = self._mode_map_list(SOLFEGE_NAMES)
+        else:
+            print(
+                "No Solfege for temperaments with %d semitones."
+                % self.number_of_semitones
+            )
+
+    def _assign_east_indian_solfege_note_names(self):
+        """
+        East Indian Solfege
+        NOTE: Solfege assignment only works for temperaments of 12 semitones.
+        """
+        self.east_indian_solfege_notes = []
+
+        if self.number_of_semitones == 12 or self.number_of_semitones == 21:
+            self.east_indian_solfege_notes = self._mode_map_list(EAST_INDIAN_NAMES)
+        else:
+            print(
+                "No EI Solfege for temperaments with %d semitones."
+                % self.number_of_semitones
+            )
+
+    def _assign_scalar_mode_numbers(self):
+        """
+        Scalar mode numbers refer to the available notes in the mode
+        NOTE: Assignment only works for temperaments of 12 semitones.
+        """
+        self.scalar_mode_numbers = []
+
+        if self.number_of_semitones == 12 or self.number_of_semitones == 21:
+            self.scalar_mode_numbers = self._mode_map_list(SCALAR_MODE_NUMBERS)
+        else:
+            print(
+                "No mode numbers for temperaments with %d semitones."
+                % self.number_of_semitones
+            )
 
     def get_number_of_semitones(self):
         """
@@ -136,6 +370,35 @@ class Scale:
             The notes defined by the temperament
         """
         return self.note_names
+
+    def set_custom_note_names(self, custom_names):
+        """
+        Custom note names defined by user
+
+        Parameters
+        ----------
+        custom_names : list
+            A list of custom names
+
+        Note: Names should not end with b or x or they will cause
+        collisions with the flat (b) and doublesharp (x) accidentals.
+        """
+        if len(custom_names) != len(self.letter_names) - 1:
+            print("A unique name must be assigned to every note in the mode.")
+            return -1
+        self.custom_note_names = custom_names[:]
+        return 0
+
+    def get_custom_note_names(self):
+        """
+        Custom note names defined by user
+
+        Returns
+        -------
+        list
+            Custom names
+        """
+        return self.custom_note_names
 
     def get_scale(self, pitch_format=None):
         """
@@ -171,3 +434,228 @@ class Scale:
         B#, which would be in the next octave, e.g., G3, A3, B3, C4...
         """
         return self.get_scale(pitch_format), self.octave_deltas
+
+    def get_letter_names(self):
+        """
+        The letter names of the notes found in the scale
+
+        Returns
+        -------
+        list
+            The letter names
+        """
+        return self.letter_names
+
+    def get_solfege_names(self):
+        """
+        The solfege names of the notes found in the scale
+
+        Returns
+        -------
+        list
+            The solfege names
+        """
+        return self.solfege_notes
+
+    def get_east_indian_solfege_names(self):
+        """
+        The East Indian solfege names of the notes found in the scale
+
+        Returns
+        -------
+        list
+            The East Indian solfege names
+        """
+        return self.east_indian_solfege_notes
+
+    def get_scalar_mode_numbers(self):
+        """
+        The scalar mode numbers corresponding to the notes found in the scale
+
+        Returns
+        -------
+        list
+            The scalar mode numbers
+        """
+        return self.scalar_mode_numbers
+
+    def name_converter(self, pitch_name, source_list):
+        """
+        Convert from a source name, e.g., Solfege, to a note name.
+        """
+        if pitch_name in source_list:
+            i = source_list.index(pitch_name)
+            return self.convert_to_generic_note_name(self.scale[i])[0]
+        pitch_name, delta = strip_accidental(pitch_name)
+        if pitch_name in source_list:
+            i = source_list.index(pitch_name)
+            note_name = self.convert_to_generic_note_name(self.scale[i])[0]
+            i = self.note_names.index(note_name)
+            i += delta
+            if i < 0:
+                i += self.number_of_semitones
+            if i > self.number_of_semitones - 1:
+                i -= self.number_of_semitones
+            return self.note_names[i]
+        return None
+
+    def pitch_name_type(self, pitch_name):
+        """
+        Check pitch type, including test for custom names
+
+        Parameters
+        ----------
+        pitch_name : str
+            pitch name to test
+
+        Returns
+        -------
+        str
+            pitch type, e.g., LETTER_NAME, SOLFEGE_NAME, etc.
+        """
+        original_notation = get_pitch_type(pitch_name)
+        if original_notation == UNKNOWN_PITCH_NAME:
+            stripped_pitch = strip_accidental(pitch_name)[0]
+            if stripped_pitch in self.custom_note_names:
+                original_notation = CUSTOM_NAME
+        return original_notation
+
+    def convert_to_generic_note_name(self, pitch_name, fixed_solfege=False):
+        """
+        Convert from a letter name used by 12-semitone temperaments to
+        a generic note name as defined by the temperament.
+        NOTE: Only for temperaments with 12 semitones.
+        """
+        pitch_name = normalize_pitch(pitch_name)
+        original_notation = self.pitch_name_type(pitch_name)
+
+        # Maybe it is already a generic name.
+        if original_notation == GENERIC_NOTE_NAME:
+            return pitch_name, 0
+
+        if self.number_of_semitones == 21:
+            if pitch_name in ALL_NOTES:
+                return self.note_names[ALL_NOTES.index(pitch_name)], 0
+
+        if original_notation == LETTER_NAME:
+            # Look for a letter name, e.g., g# or ab
+            if "#" in pitch_name and is_a_sharp(pitch_name):
+                return self.note_names[find_sharp_index(pitch_name)], 0
+            if is_a_flat(pitch_name):
+                return self.note_names[find_flat_index(pitch_name)], 0
+            # Catch cb, bx, etc.
+            if pitch_name in EQUIVALENT_SHARPS:
+                return (
+                    self.note_names[
+                        CHROMATIC_NOTES_SHARP.index(EQUIVALENT_SHARPS[pitch_name])
+                    ],
+                    0,
+                )
+            if pitch_name in EQUIVALENT_FLATS:
+                return (
+                    self.note_names[find_flat_index(EQUIVALENT_FLATS[pitch_name])],
+                    0,
+                )
+            if pitch_name in EQUIVALENTS:
+                if "#" in EQUIVALENTS[pitch_name][0]:
+                    return (
+                        self.note_names[find_sharp_index(EQUIVALENTS[pitch_name][0])],
+                        0,
+                    )
+                return (
+                    self.note_names[find_flat_index(EQUIVALENTS[pitch_name][0])],
+                    0,
+                )
+
+        if original_notation == SOLFEGE_NAME:
+            # Look for a Solfege name
+            if fixed_solfege:
+                note_name = self.name_converter(pitch_name, self.solfege_notes)
+                if note_name is not None:
+                    return note_name, 0
+            else:
+                if "#" in pitch_name and pitch_name in SOLFEGE_SHARP:
+                    return self.note_names[SOLFEGE_SHARP.index(pitch_name)], 0
+                if pitch_name in SOLFEGE_FLAT:
+                    return self.note_names[SOLFEGE_FLAT.index(pitch_name)], 0
+
+        if original_notation == CUSTOM_NAME:
+            # Look for a Custom name
+            if len(self.custom_note_names) > 0:
+                note_name = self.name_converter(pitch_name, self.custom_note_names)
+                if note_name is not None:
+                    return note_name, 0
+            if fixed_solfege:
+                stripped_pitch = strip_accidental(pitch_name)[0]
+                note_name = self.name_converter(stripped_pitch, self.custom_note_names)
+                if note_name is not None:
+                    return note_name, 0
+            else:
+                stripped_pitch = strip_accidental(pitch_name)[0]
+                if "#" in pitch_name and stripped_pitch in self.custom_note_names:
+                    i = self.custom_note_names.index(stripped_pitch)
+                    i += 1
+                    if i > len(self.note_names):
+                        i = 0
+                    return self.note_names[i], 0
+                if pitch_name in SCALAR_NAMES_FLAT:
+                    i = self.custom_note_names.index(stripped_pitch)
+                    i -= 1
+                    if i > 0:
+                        i = len(self.note_names)
+                    return self.note_names[i], 0
+
+        if original_notation == EAST_INDIAN_SOLFEGE_NAME:
+            # Look for a East Indian Solfege name
+            if fixed_solfege:
+                note_name = self.name_converter(
+                    pitch_name, self.east_indian_solfege_notes
+                )
+                if note_name is not None:
+                    return note_name, 0
+            else:
+                if "#" in pitch_name and pitch_name in EAST_INDIAN_SHARP:
+                    return self.note_names[EAST_INDIAN_SHARP.index(pitch_name)], 0
+                if pitch_name in EAST_INDIAN_FLAT:
+                    return self.note_names[EAST_INDIAN_FLAT.index(pitch_name)], 0
+
+        if original_notation == SCALAR_MODE_NUMBER:
+            # Look for a scalar mode number
+            if fixed_solfege:
+                note_name = self.name_converter(pitch_name, self.scalar_mode_numbers)
+                if note_name is not None:
+                    return note_name, 0
+            else:
+                if "#" in pitch_name and pitch_name in SCALAR_NAMES_SHARP:
+                    return self.note_names[SCALAR_NAMES_SHARP.index(pitch_name)], 0
+                if pitch_name in SCALAR_NAMES_FLAT:
+                    return self.note_names[SCALAR_NAMES_FLAT.index(pitch_name)], 0
+
+        print("Pitch name %s not found." % pitch_name)
+        return pitch_name, -1
+
+    def generic_note_name_to_letter_name(self, note_name, prefer_sharps=True):
+        """
+        Convert from a generic note name as defined by the temperament
+        to a letter name used by 12-semitone temperaments.
+        NOTE: Only for temperaments with 12 semitones.
+        """
+        note_name = normalize_pitch(note_name)
+        # Maybe it is already a letter name?
+        if is_a_sharp(note_name):
+            return note_name, 0
+        if is_a_flat(note_name):
+            return note_name, 0
+        if self.number_of_semitones == 21:
+            return ALL_NOTES[self.note_names.index(note_name)], 0
+        if self.number_of_semitones != 12:
+            print("Cannot convert %s to a letter name." % note_name)
+            return note_name, -1
+
+        if note_name in self.note_names:
+            if prefer_sharps:
+                return CHROMATIC_NOTES_SHARP[self.note_names.index(note_name)], 0
+            return CHROMATIC_NOTES_FLAT[self.note_names.index(note_name)], 0
+
+        print("Note name %s not found." % note_name)
+        return note_name, -1

--- a/src/musicUtils/.archive/scale.py
+++ b/src/musicUtils/.archive/scale.py
@@ -110,13 +110,18 @@ class Scale:
         """
         self.key = key
         self.prefer_sharps = prefer_sharps
+        self.fixed_solfege = False
         # Calculate the number of semitones by summing up the half
         # steps.
         if half_steps_pattern is None:
             self.number_of_semitones = number_of_semitones
-            half_steps_pattern = []
-            for i in range(self.number_of_semitones):
-                half_steps_pattern.append(1)
+            if self.number_of_semitones == 12:
+                # Default to Major scale
+                half_steps_pattern = [2, 2, 1, 2, 2, 2, 1]
+            else:
+                half_steps_pattern = []
+                for i in range(self.number_of_semitones):
+                    half_steps_pattern.append(1)
         else:
             self.number_of_semitones = 0
             for step in half_steps_pattern:
@@ -158,7 +163,6 @@ class Scale:
             for i in range(self.number_of_semitones):
                 self.note_names.append("n%d" % i)
 
-        self.generic_names = self.get_scale()
         if self.number_of_semitones == 12:
             if self.prefer_sharps:
                 self.letter_names = self.get_scale(pitch_format=CHROMATIC_NOTES_SHARP)
@@ -171,18 +175,50 @@ class Scale:
             # notation, ^ and v, for 41.
             self.letter_names = None
 
+        self.generic_note_names = self.get_scale()
+        if self.letter_names is not None:
+            self.notes_in_scale = self.letter_names[:]
+        else:
+            self.notes_in_scale = self.generic_note_names[:]
+
         self.solfege_notes = []
         self.east_indian_solfege_notes = []
         self.scalar_mode_numbers = []
         self.custom_note_names = []
 
         if self.number_of_semitones == 12:
-            self.letter_names = self._normalize_scale(self.letter_names)[:]
+            self.letter_names = self.normalize_scale(self.letter_names)[:]
             self._assign_solfege_note_names()
             self._assign_east_indian_solfege_note_names()
             self._assign_scalar_mode_numbers()
 
-    def _normalize_scale(self, scale):
+    def set_fixed_solfege(self, state=False):
+        """
+        Fixed Solfege means that the mapping between Solfege and
+        letter names is fixed: do == c, re == d, ...
+
+        Moveable (not fixed) Solfege means that do == the first note
+        in the scale, etc.
+
+        Parameters
+        ----------
+        state : boolean
+            State to set fixed Solfege: True or False
+        """
+        self.fixed_solfege = state
+
+    def get_fixed_solfege(self):
+        """
+        Returns the fixed Solfege state
+
+        Returns
+        -------
+        boolean
+            State of fixed Solfege
+        """
+        return self.fixed_solfege
+
+    def normalize_scale(self, scale):
         """
         Normalize the letter names by converting double sharps and double
         flats.
@@ -277,9 +313,9 @@ class Scale:
         """
         return_list = []
         # Don't include the octave note.
-        mode_length = len(self.letter_names) - 1
+        mode_length = len(self.notes_in_scale) - 1
         offset = "cdefgab".index(self.letter_names[0][0])
-        for i in range(len(self.letter_names)):
+        for i in range(len(self.notes_in_scale)):
             j = "cdefgab".index(self.letter_names[i][0]) - offset
             if j < 0:
                 j += len(source_list)
@@ -383,7 +419,7 @@ class Scale:
         Note: Names should not end with b or x or they will cause
         collisions with the flat (b) and doublesharp (x) accidentals.
         """
-        if len(custom_names) != len(self.letter_names) - 1:
+        if len(custom_names) != len(self.notes_in_scale) - 1:
             print("A unique name must be assigned to every note in the mode.")
             return -1
         self.custom_note_names = custom_names[:]
@@ -520,7 +556,7 @@ class Scale:
                 original_notation = CUSTOM_NAME
         return original_notation
 
-    def convert_to_generic_note_name(self, pitch_name, fixed_solfege=False):
+    def convert_to_generic_note_name(self, pitch_name):
         """
         Convert from a letter name used by 12-semitone temperaments to
         a generic note name as defined by the temperament.
@@ -569,7 +605,7 @@ class Scale:
 
         if original_notation == SOLFEGE_NAME:
             # Look for a Solfege name
-            if fixed_solfege:
+            if self.fixed_solfege:
                 note_name = self.name_converter(pitch_name, self.solfege_notes)
                 if note_name is not None:
                     return note_name, 0
@@ -585,7 +621,7 @@ class Scale:
                 note_name = self.name_converter(pitch_name, self.custom_note_names)
                 if note_name is not None:
                     return note_name, 0
-            if fixed_solfege:
+            if self.fixed_solfege:
                 stripped_pitch = strip_accidental(pitch_name)[0]
                 note_name = self.name_converter(stripped_pitch, self.custom_note_names)
                 if note_name is not None:
@@ -607,7 +643,7 @@ class Scale:
 
         if original_notation == EAST_INDIAN_SOLFEGE_NAME:
             # Look for a East Indian Solfege name
-            if fixed_solfege:
+            if self.fixed_solfege:
                 note_name = self.name_converter(
                     pitch_name, self.east_indian_solfege_notes
                 )
@@ -621,7 +657,7 @@ class Scale:
 
         if original_notation == SCALAR_MODE_NUMBER:
             # Look for a scalar mode number
-            if fixed_solfege:
+            if self.fixed_solfege:
                 note_name = self.name_converter(pitch_name, self.scalar_mode_numbers)
                 if note_name is not None:
                     return note_name, 0
@@ -659,3 +695,706 @@ class Scale:
 
         print("Note name %s not found." % note_name)
         return note_name, -1
+
+    def _convert_from_note_name(self, note_name, target_list):
+        """
+        Convert from a note name to a format specified in the target list.
+        """
+        note_name = normalize_pitch(note_name)
+        # Maybe it is already in the list?
+        if note_name in target_list:
+            return note_name, 0
+        if self.number_of_semitones != 12:
+            print("Cannot convert %s to a letter name." % note_name)
+            return note_name, -1
+
+        if note_name in self.note_names:
+            # First find the corresponding letter name
+            letter_name = CHROMATIC_NOTES_SHARP[self.note_names.index(note_name)]
+            # Next, find the closest note in the scale.
+            i, distance, error = self.closest_note(letter_name)[1:]
+            # Use the index to get the corresponding solfege note
+            if error < 0:
+                print("Cannot find closest note to ", letter_name)
+                return note_name, -1
+            if distance == 0:
+                return target_list[i], 0
+            # Remove any accidental
+            target_note, delta = strip_accidental(target_list[i])
+            # Add back in the appropriate accidental
+            delta += distance
+            return target_note + ["bb", "b", "", "#", "x"][delta + 2], 0
+
+        print("Note name %s not found." % note_name)
+        return note_name, -1
+
+    def _find_moveable(self, note_name, sharp_scale, flat_scale, prefer_sharps):
+        """
+        Find the equivalent moveable note.
+        """
+        note_name = normalize_pitch(note_name)
+        if note_name in sharp_scale:
+            return note_name, 0
+        if note_name in flat_scale:
+            return note_name, 0
+        if self.number_of_semitones != 12:
+            print("Cannot convert %s" % note_name)
+            return note_name, -1
+
+        if note_name in self.note_names:
+            if prefer_sharps:
+                return sharp_scale[self.note_names.index(note_name)], 0
+            return flat_scale[self.note_names.index(note_name)], 0
+
+        print("Cannot convert %s" % note_name)
+        return note_name, -1
+
+    def _generic_note_name_to_letter_name(self, note_name, prefer_sharps=True):
+        """
+        Convert from a generic note name as defined by the temperament
+        to a letter name used by 12-semitone temperaments.
+        NOTE: Only for temperaments with 12 semitones.
+        """
+        note_name = normalize_pitch(note_name)
+        # Maybe it is already a letter name?
+        if is_a_sharp(note_name):
+            return note_name, 0
+        if is_a_flat(note_name):
+            return note_name, 0
+        if self.number_of_semitones == 21:
+            return ALL_NOTES[self.note_names.index(note_name)], 0
+        if self.number_of_semitones != 12:
+            print("Cannot convert %s to a letter name." % note_name)
+            return note_name, -1
+
+        if note_name in self.note_names:
+            if prefer_sharps:
+                return CHROMATIC_NOTES_SHARP[self.note_names.index(note_name)], 0
+            return CHROMATIC_NOTES_FLAT[self.note_names.index(note_name)], 0
+
+        print("Note name %s not found." % note_name)
+        return note_name, -1
+
+    def _generic_note_name_to_solfege(self, note_name, prefer_sharps=True):
+        """
+        Convert from a generic note name as defined by the temperament
+        to a solfege note used by 12-semitone temperaments.
+        NOTE: Only for temperaments with 12 semitones.
+        """
+        if self.fixed_solfege:
+            return self._convert_from_note_name(note_name, self.solfege_notes)
+
+        return self._find_moveable(
+            note_name, SOLFEGE_SHARP, SOLFEGE_FLAT, prefer_sharps
+        )
+
+    def _generic_note_name_to_east_indian_solfege(self, note_name, prefer_sharps=True):
+        """
+        Convert from a generic note name as defined by the temperament
+        to an East Indian solfege note used by 12-semitone temperaments.
+        NOTE: Only for temperaments with 12 semitones.
+        """
+
+        if self.fixed_solfege:
+            return self._convert_from_note_name(
+                note_name, self.east_indian_solfege_notes
+            )
+
+        return self._find_moveable(
+            note_name, EAST_INDIAN_SHARP, EAST_INDIAN_FLAT, prefer_sharps
+        )
+
+    def _generic_note_name_to_scalar_mode_number(self, note_name, prefer_sharps=True):
+        """
+        Convert from a generic note name as defined by the temperament
+        to a scalar mode number used by 12-semitone temperaments.
+        NOTE: Only for temperaments with 12 semitones.
+        """
+
+        if self.fixed_solfege:
+            return self._convert_from_note_name(note_name, self.scalar_mode_numbers)
+
+        return self._find_moveable(
+            note_name, SCALAR_NAMES_SHARP, SCALAR_NAMES_FLAT, prefer_sharps
+        )
+
+    def _generic_note_name_to_custom_note_name(self, note_name):
+        """
+        Convert from a generic note name as defined by the temperament
+        to a custom_note_name used by 12-semitone temperaments.
+        NOTE: Only for temperaments with 12 semitones.
+        """
+
+        return self._convert_from_note_name(note_name, self.custom_note_names)
+
+    def modal_pitch_to_letter(self, modal_index):
+        """
+        Given a modal number, return the corresponding pitch in the scale
+        (and any change in octave).
+
+        Parameters
+        ----------
+        modal_index : int
+            The modal index specifies an index into the scale. If the
+            index is >= mode length or < 0, a relative change in octave
+            is also calculated.
+
+        Returns
+        -------
+        str
+            The pitch that is the result of indexing the scale by the
+            modal index.
+
+        int
+            The relative change in octave due to mapping the modal index
+            to the mode length
+        """
+        mode_length = len(self.notes_in_scale) - 1
+        modal_index = int(modal_index)
+        delta_octave = int(modal_index / mode_length)
+        if modal_index < 0:
+            delta_octave -= 1
+            while modal_index < 0:
+                modal_index += mode_length
+        while modal_index > mode_length - 1:
+            modal_index -= mode_length
+        return self.notes_in_scale[modal_index], delta_octave
+
+    def note_in_scale(self, target):
+        """
+        Given a pitch, check to see if it is in the scale.
+
+        Parameters
+        ----------
+        target : str
+            The target pitch specified as a pitch letter, e.g., c#, fb.
+
+        Returns
+        -------
+        boolean
+            True if the note is in the scale
+        """
+        return self.closest_note(target)[2] == 0
+
+    def _map_to_semitone_range(self, i, delta_octave):
+        """
+        Ensure that an index value is within the range of the temperament, e.g.,
+        i == 12 would be mapped to 0 with a change in octave +1 for a
+        temperament with 12 semitones.
+
+        Parameters
+        ----------
+        i : int
+            Index value into semitones
+
+        delta_octave : int
+            Any previous change in octave that needs to be preserved
+
+        Returns
+        -------
+        int
+            Index mapped to semitones
+
+        int
+            Any additonal change in octave due to mapping
+        """
+        while i < 0:
+            i += self.number_of_semitones
+            delta_octave -= 1
+        while i > self.number_of_semitones - 1:
+            i -= self.number_of_semitones
+            delta_octave += 1
+        return i, delta_octave
+
+    def semitone_transform(self, starting_pitch, number_of_half_steps):
+        """
+        Given a starting pitch, add a semitone transform and return
+        the resultant pitch (and any change in octave).
+
+        Parameters
+        ----------
+        starting_pitch : str
+            The starting pitch specified as a pitch letter, e.g., c#, fb.
+
+        number_of_half_steps : int
+            Half steps are steps in the notes defined by the temperament
+
+        Returns
+        -------
+        str
+            The pitch that is the number of half steps from the starting
+            pitch.
+
+        int
+            The relative change in octave between the starting pitch and the
+            new pitch.
+
+        int
+            error code
+        """
+        starting_pitch = normalize_pitch(starting_pitch)
+        original_notation = self.pitch_name_type(starting_pitch)
+        delta_octave = 0
+        if self.number_of_semitones == 12:
+            if original_notation == LETTER_NAME:
+                if is_a_sharp(starting_pitch):
+                    i = find_sharp_index(starting_pitch)
+                    i += number_of_half_steps
+                    i, delta_octave = self._map_to_semitone_range(i, delta_octave)
+                    return CHROMATIC_NOTES_SHARP[i], delta_octave, 0
+                if is_a_flat(starting_pitch):
+                    i = find_flat_index(starting_pitch)
+                    i += number_of_half_steps
+                    i, delta_octave = self._map_to_semitone_range(i, delta_octave)
+                    return CHROMATIC_NOTES_FLAT[i], delta_octave, 0
+                stripped_pitch, delta = strip_accidental(starting_pitch)
+                if stripped_pitch in self.note_names:
+                    note_name = stripped_pitch
+                    error = 0
+                else:
+                    note_name, error = self.convert_to_generic_note_name(stripped_pitch)
+                if error == 0:
+                    if note_name in self.note_names:
+                        i = self.note_names.index(note_name)
+                        i += number_of_half_steps
+                        i, delta_octave = self._map_to_semitone_range(
+                            i + delta, delta_octave
+                        )
+                        return self.note_names[i], delta_octave, 0
+                print("Cannot find %s in note names." % starting_pitch)
+                return starting_pitch, 0, -1
+
+            note_name, error = self.convert_to_generic_note_name(starting_pitch)
+            stripped_pitch, delta = strip_accidental(note_name)  # starting_pitch)
+            if stripped_pitch in self.note_names:
+                i = self.note_names.index(stripped_pitch)
+                i += number_of_half_steps
+                i, delta_octave = self._map_to_semitone_range(i + delta, delta_octave)
+                if original_notation == SOLFEGE_NAME:
+                    return (
+                        self._generic_note_name_to_solfege(
+                            self.note_names[i], "#" in starting_pitch
+                        )[0],
+                        delta_octave,
+                        0,
+                    )
+                if original_notation == EAST_INDIAN_SOLFEGE_NAME:
+                    return (
+                        self._generic_note_name_to_east_indian_solfege(
+                            self.note_names[i], "#" in starting_pitch
+                        )[0],
+                        delta_octave,
+                        0,
+                    )
+                if original_notation == SCALAR_MODE_NUMBER:
+                    return (
+                        self._generic_note_name_to_scalar_mode_number(
+                            self.note_names[i], "#" in starting_pitch
+                        )[0],
+                        delta_octave,
+                        0,
+                    )
+                return self.note_names[i], delta_octave, 0
+            print("Cannot find %s in note names." % starting_pitch)
+            return starting_pitch, 0, -1
+
+        def __calculate_increment(delta, j):
+            """
+            When there both sharps and flats in a scale, we skip some of the
+            accidental as we navigate the semitones.
+            """
+            if delta == 0 and j % 3 == 2:
+                return 2
+            if delta == 1 and j % 3 == 1:
+                return 2
+            if delta == -1 and j % 3 == 2:
+                return 2
+            return 1
+
+        stripped_pitch, delta = strip_accidental(starting_pitch)
+        # If there are 21 semitones, assume c, c#, db, d, d#,
+        # eb... but still go from c# to d or db to c.
+        if self.number_of_semitones == 21:
+            if starting_pitch in ALL_NOTES:
+                i = ALL_NOTES.index(starting_pitch)
+                if number_of_half_steps > 0:
+                    for j in range(number_of_half_steps):
+                        i += __calculate_increment(delta, j)
+                else:
+                    for j in range(-number_of_half_steps):
+                        i -= __calculate_increment(delta, j)
+                i, delta_octave = self._map_to_semitone_range(i, delta_octave)
+                return ALL_NOTES[i], delta_octave, 0
+            if stripped_pitch in self.note_names:
+                i = self.note_names.index(stripped_pitch)
+                if number_of_half_steps > 0:
+                    for j in range(number_of_half_steps):
+                        i += __calculate_increment(delta, j)
+                else:
+                    for j in range(-number_of_half_steps):
+                        i -= __calculate_increment(delta, j)
+                i, delta_octave = self._map_to_semitone_range(i, delta_octave)
+                return self.note_names[i], delta_octave, 0
+
+        if stripped_pitch in self.note_names:
+            i = self.note_names.index(stripped_pitch)
+            i += number_of_half_steps
+            i, delta_octave = self._map_to_semitone_range(i + delta, delta_octave)
+            return self.note_names[i], delta_octave, 0
+
+        print("Cannot find %s in note names." % starting_pitch)
+        return starting_pitch, 0, -1
+
+    def _map_to_scalar_range(self, i, delta_octave):
+        """
+        Ensure that an index value is within the range of the scale, e.g.,
+        i == 8 would be mapped to 0 with a change in octave +1 for a
+        7-tone scale.
+
+        Parameters
+        ----------
+        i : int
+            Index value into scale
+
+        delta_octave : int
+            Any previous change in octave that needs to be preserved
+
+        Returns
+        -------
+        int
+            Index mapped to scale
+
+        int
+            Any additonal change in octave due to mapping
+        """
+        mode_length = len(self.notes_in_scale) - 1
+        while i < 0:
+            i += mode_length
+            delta_octave -= 1
+        while i > mode_length - 1:
+            i -= mode_length
+            delta_octave += 1
+        return i, delta_octave
+
+    def scalar_transform(self, starting_pitch, number_of_scalar_steps):
+        """
+        Given a starting pitch, add a scalar transform and return
+        the resultant pitch (and any change in octave).
+
+        Parameters
+        ----------
+        starting_pitch : str
+            The starting pitch specified as a pitch letter, e.g., c#, fb.
+            Note that the starting pitch may or may not be in the scale.
+
+        number_of_scalar_steps : int
+            Scalar steps are steps in the scale (as opposed to half-steps)
+
+        Returns
+        -------
+        str
+            The pitch that is the number of scalar steps from the starting
+            pitch.
+
+        int
+            The relative change in octave between the starting pitch and the
+            new pitch.
+
+        int
+            error code
+        """
+        starting_pitch = normalize_pitch(starting_pitch)
+        original_notation = self.pitch_name_type(starting_pitch)
+        prefer_sharps = "#" in starting_pitch
+        # The calculation is done in the generic note namespace
+        generic_pitch = self.convert_to_generic_note_name(starting_pitch)[0]
+        # First, we need to find the closest note to our starting
+        # pitch.
+        closest_index, distance, error = self.closest_note(generic_pitch)[1:]
+        if error < 0:
+            return starting_pitch, 0, error
+        # Next, we add the scalar interval -- the steps are in the
+        # scale.
+        new_index = closest_index + number_of_scalar_steps
+        # We also need to determine if we will be travelling more than
+        # one octave.
+        mode_length = len(self.notes_in_scale) - 1
+        delta_octave = int(new_index / mode_length)
+
+        # We need an index value between 0 and mode length - 1.
+        normalized_index = new_index
+        while normalized_index < 0:
+            normalized_index += mode_length
+        while normalized_index > mode_length - 1:
+            normalized_index -= mode_length
+        generic_new_note = self.generic_note_names[normalized_index]
+        new_note = self._restore_format(
+            generic_new_note, original_notation, prefer_sharps
+        )
+
+        # We need to keep track of whether or not we crossed C, which
+        # is the octave boundary.
+        if new_index < 0:
+            delta_octave -= 1
+
+        # Do we need to take into account the distance from the
+        # closest scalar note?
+        if distance == 0:
+            return new_note, delta_octave, 0
+        i = self.note_names.index(generic_new_note)
+        i, delta_octave = self._map_to_scalar_range(i - distance, delta_octave)
+        return (
+            self._restore_format(self.note_names[i], original_notation, prefer_sharps),
+            delta_octave,
+            0,
+        )
+
+    def generic_note_name_convert_to_type(
+        self, pitch_name, target_type, prefer_sharps=True
+    ):
+        """
+        Given a generic note name, convert it to a pitch name type.
+
+        Parameters
+        ----------
+        pitch_name : str
+            Source generic note name
+
+        target_type : str
+            One of the predefined types, e.g., LETTER_NAME, SOLFEGE_NAME, etc.
+
+        prefer_sharps : boolean
+            If there is a choice, should we use a sharp or a flat?
+
+        Returns
+        -------
+        str
+            Converted note name
+        """
+        return self._restore_format(pitch_name, target_type, prefer_sharps)
+
+    def _restore_format(self, pitch_name, original_notation, prefer_sharps):
+        """
+        Format convertor (could be done with a dictionary?)
+        """
+        if original_notation == GENERIC_NOTE_NAME:
+            return pitch_name
+        if original_notation == LETTER_NAME:
+            return self._generic_note_name_to_letter_name(pitch_name, prefer_sharps)[0]
+        if original_notation == SOLFEGE_NAME:
+            return self._generic_note_name_to_solfege(pitch_name, prefer_sharps)[0]
+        if original_notation == CUSTOM_NAME:
+            return self._generic_note_name_to_custom_note_name(pitch_name)[0]
+        if original_notation == SCALAR_MODE_NUMBER:
+            return self._generic_note_name_to_scalar_mode_number(pitch_name)[0]
+        if original_notation == EAST_INDIAN_SOLFEGE_NAME:
+            return self._generic_note_name_to_east_indian_solfege(pitch_name)[0]
+        return pitch_name
+
+    def _pitch_to_note_number(self, pitch_name, octave):
+        """
+        Find the pitch number, e.g., A4 --> 57
+        """
+        generic_name = self.convert_to_generic_note_name(pitch_name)[0]
+        i = (octave * self.number_of_semitones) + self.note_names.index(generic_name)
+        return int(i)
+
+    def semitone_distance(self, pitch_a, octave_a, pitch_b, octave_b):
+        """
+        Calculate the distance between two notes in semitone steps
+
+        Parameters
+        ----------
+        pitch_a : str
+            Pitch name one of two
+        octave_a : int
+            Octave number one of two
+        pitch_b : str
+            Pitch name two of two
+        octave_b : int
+            Octave number two of two
+
+        Returns
+        -------
+        int
+            Distance calculated in semitone steps
+        """
+        return self._pitch_to_note_number(
+            pitch_b, octave_b
+        ) - self._pitch_to_note_number(pitch_a, octave_a)
+
+    def scalar_distance(self, pitch_a, octave_a, pitch_b, octave_b):
+        """
+        Calculate the distance between two notes in scalar steps
+
+        Parameters
+        ----------
+        pitch_a : str
+            Pitch name one of two
+        octave_a : int
+            Octave number one of two
+        pitch_b : str
+            Pitch name two of two
+        octave_b : int
+            Octave number two of two
+
+        Returns
+        -------
+        int
+            Distance calculated in scalar steps
+        int
+            Any semitone rounding error in the calculation
+        """
+        closest1 = self.closest_note(pitch_a)
+        closest2 = self.closest_note(pitch_b)
+        return (closest2[1] + octave_b * (len(self.notes_in_scale) - 1)) - (
+            closest1[1] + octave_a * (len(self.notes_in_scale) - 1)
+        ), closest1[2] + closest2[2]
+
+    def invert(
+        self, pitch_name, octave, invert_point_pitch, invert_point_octave, invert_mode
+    ):
+        """
+        Invert will rotate a series of notes around an invert point.
+        There are three different invert modes: even, odd, and
+        scalar. In even and odd modes, the rotation is based on half
+        steps. In even and scalar mode, the point of rotation is the
+        given note. In odd mode, the point of rotation is shifted up
+        by a 1/4 step, enabling rotation around a point between two
+        notes. In "scalar" mode, the scalar interval is preserved
+        around the point of rotation.
+
+        Parameters
+        ----------
+        pitch_name : str
+            The pitch name of the note to be rotated
+        octave : int
+            The octave of the note to be rotated
+        invert_point_name : str
+            The pitch name of the axis of inversion
+        invert_point_octave : int
+            The octave of the axis of inversion
+
+        Returns
+        -------
+        str
+            Pitch name of the inverted note
+        int
+            Octave of the inverted note
+        """
+        if isinstance(invert_mode, int):
+            if invert_mode % 2 == 0:
+                invert_mode = "even"
+            else:
+                invert_mode = "odd"
+
+        if invert_mode in ["even", "odd"]:
+            delta = self.semitone_distance(
+                invert_point_pitch, invert_point_octave, pitch_name, octave
+            )
+            if invert_mode == "even":
+                delta *= 2
+            elif invert_mode == "odd":
+                delta = 2 * delta - 1
+            inverted_pitch, delta_octave = self.semitone_transform(pitch_name, -delta)[
+                0:2
+            ]
+            return inverted_pitch, octave + delta_octave
+
+        if invert_mode == "scalar":
+            delta = self.scalar_distance(
+                invert_point_pitch, invert_point_octave, pitch_name, octave
+            )[0]
+            delta *= 2
+            inverted_pitch, delta_octave = self.scalar_transform(pitch_name, -delta)[
+                0:2
+            ]
+            return inverted_pitch, octave + delta_octave
+
+        print("Unknown invert mode", invert_mode)
+        return pitch_name, octave
+
+    def closest_note(self, target):
+        """
+        Given a target pitch, what is the closest note in the current
+        key signature (key and mode)?
+
+        Parameters
+        ----------
+        target : str
+            target pitch specified as a pitch letter, e.g., c#, fb
+
+        Returns
+        -------
+        str
+            The closest pitch to the target pitch in the scale.
+        int
+            The scalar index value of the closest pitch in the scale
+            (If the target is midway between two scalar pitches, the
+            lower pitch is returned.)
+        int
+            The distance in semitones (half steps) from the target
+            pitch to the scalar pitch (If the target is higher than
+            the scalar pitch, then distance > 0. If the target is
+            lower than the scalar pitch then distance < 0. If the
+            target matches a scale pitch, then distance = 0.)
+        int
+            error code (0 means success)
+        """
+        target = normalize_pitch(target)
+        original_notation = self.pitch_name_type(target)
+        prefer_sharps = "#" in target
+        # The calculation is done in the generic note namespace
+        target = self.convert_to_generic_note_name(target)[0]
+        stripped_target, delta = strip_accidental(target)
+        if stripped_target in self.note_names:
+            i = self.note_names.index(stripped_target)
+            i = self._map_to_semitone_range(i + delta, 0)[0]
+        target = self.note_names[i]
+
+        # First look for an exact match.
+        for i in range(len(self.notes_in_scale) - 1):
+            if target == self.generic_note_names[i]:
+                return (
+                    self._restore_format(target, original_notation, prefer_sharps),
+                    i,
+                    0,
+                    0,
+                )
+
+        # Then look for the nearest note in the scale.
+        if target in self.note_names:
+            idx = self.note_names.index(target)
+            # Look up for a note in the scale.
+            distance = self.number_of_semitones  # max distance
+            n = 0
+            for i in range(len(self.notes_in_scale) - 1):
+                ii = self.note_names.index(self.generic_note_names[i])
+                n = ii - idx
+                m = ii + self.number_of_semitones - idx
+                if abs(n) < abs(distance):
+                    closest_note = self.generic_note_names[i]
+                    distance = n
+                if abs(m) < abs(distance):
+                    closest_note = self.generic_note_names[i]
+                    distance = m
+            if distance < self.number_of_semitones:
+                return (
+                    self._restore_format(
+                        closest_note, original_notation, prefer_sharps
+                    ),
+                    self.generic_note_names.index(closest_note),
+                    distance,
+                    0,
+                )
+
+            print("Closest note to %s not found." % target)
+            return (
+                self._restore_format(target, original_notation, prefer_sharps),
+                0,
+                0,
+                -1,
+            )
+
+        print("Note %s not found." % target)
+        return self._restore_format(target, original_notation, prefer_sharps), 0, 0, -1

--- a/src/musicUtils/.archive/temperament.py
+++ b/src/musicUtils/.archive/temperament.py
@@ -233,6 +233,9 @@ class Temperament:
 
         name : str
             The name of a temperament, e.g., "equal", "just intonation". etc.
+
+        octave_ratio : float
+            The ratio between octaves (2 by default)
         """
         self.name = name
         self.octave_length = 12  # in semitones
@@ -592,7 +595,7 @@ class Temperament:
         Parameters
         ----------
         octave_ratio : float
-        The ratio between octaves
+            The ratio between octaves
         """
         self.octave_ratio = octave_ratio
 

--- a/src/musicUtils/.archive/temperament.py
+++ b/src/musicUtils/.archive/temperament.py
@@ -223,7 +223,7 @@ class Temperament:
     generic_note_names = []  # An array of names for each note in an octave
     C0 = 16.3516  # By default, we use C in Octave 0 as our base frequency.
 
-    def __init__(self, name="equal"):
+    def __init__(self, name="equal", octave_ratio=2):
         """
         Initialize the class. A temperament will be generated but it can
         subsequently be overriden.
@@ -240,6 +240,8 @@ class Temperament:
         self.number_of_octaves = 8
         self.ratios = None
         self.intervals = None
+        # By default, going up by one octave doubles the frequency.
+        self.octave_ratio = octave_ratio
         self.generate(self.name)
 
     def tune(self, pitch_name, octave, frequency):
@@ -272,9 +274,9 @@ class Temperament:
             return
 
         if self.ratios is not None and self.intervals is not None:
-            self.base_frequency = (frequency / 2 ** octave) / self.ratios[
-                self.intervals[i]
-            ]
+            self.base_frequency = \
+                (frequency / self.octave_ratio ** octave) / (
+                    self.ratios[self.intervals[i]] * self.octave_ratio / 2)
             self.generate(self.name)
         return
 
@@ -581,6 +583,19 @@ class Temperament:
         for i in range(self.octave_length):
             self.generic_note_names.append("n%d" % i)
 
+    def set_octave_ratio(self, octave_ratio):
+        """
+        The octave ratio is used to determine the size of an octave. By
+        default, it is 2:1, so going up by one octave will double the
+        frequency. But this can be overriden.
+
+        Parameters
+        ----------
+        octave_ratio : float
+        The ratio between octaves
+        """
+        self.octave_ratio = octave_ratio
+
     def generate(self, name):
         """
         Generate creates one of the predefined temperaments based on the
@@ -633,7 +648,7 @@ class Temperament:
             for i in range(self.octave_length):
                 if i == 0:
                     continue
-                self.freqs.append(c * ratios[intervals[i]])
+                self.freqs.append(c * ratios[intervals[i]] * self.octave_ratio / 2)
 
         self._generate_generic_note_names()
 
@@ -659,8 +674,8 @@ class Temperament:
         self.octave_length = nsteps
         self.freqs = [self.base_frequency]
 
-        # nth root of 2
-        root = 2 ** (1 / nsteps)
+        # nth root of the octave ratio (2 by default)
+        root = self.octave_ratio ** (1 / nsteps)
         for octave in range(self.number_of_octaves):
             for i in range(self.octave_length):
                 if i == 0:
@@ -683,7 +698,8 @@ class Temperament:
             frequencies in an octave. The dictionary keys are defined
             in the intervals list. Each ratio (between 1 and 2) is applied
             to the base frequency of the octave. The final frequency
-            should always be equal to 2.
+            should always be equal to 2. This value gets modulated by
+            the octave ratio.
 
         name : str
             The name associated with the custom temperament
@@ -698,7 +714,7 @@ class Temperament:
             for i in range(self.octave_length):
                 if i == 0:
                     continue
-                self.freqs.append(c * ratios[intervals[i]])
+                self.freqs.append(c * ratios[intervals[i]] * self.octave_ratio / 2)
 
         self._generate_generic_note_names()
 

--- a/src/musicUtils/.archive/temperament.py
+++ b/src/musicUtils/.archive/temperament.py
@@ -277,9 +277,9 @@ class Temperament:
             return
 
         if self.ratios is not None and self.intervals is not None:
-            self.base_frequency = \
-                (frequency / self.octave_ratio ** octave) / (
-                    self.ratios[self.intervals[i]] * self.octave_ratio / 2)
+            self.base_frequency = (frequency / self.octave_ratio ** octave) / (
+                self.ratios[self.intervals[i]] * self.octave_ratio / 2
+            )
             self.generate(self.name)
         return
 

--- a/src/musicUtils/.archive/utils_unittest.py
+++ b/src/musicUtils/.archive/utils_unittest.py
@@ -56,7 +56,6 @@ def round(f, d):
 
 class MusicUtilsTestCase(unittest.TestCase):
     def test_current_note(self):
-        print("CURRENT NOTE TESTS")
         cp = CurrentPitch()
 
         self.assertEqual(
@@ -123,9 +122,7 @@ class MusicUtilsTestCase(unittest.TestCase):
             392.0,
         )
 
-    def test_scale(self):
-        print("SCALE TESTS")
-        print("c major")
+    def test_c_major_scale(self):
         s = Scale([2, 2, 1, 2, 2, 2, 1], 0)  # C Major
         self.assertTrue(
             compare_scales(
@@ -153,7 +150,8 @@ class MusicUtilsTestCase(unittest.TestCase):
                 ["c", "d", "e", "f", "g", "a", "b", "c"],
             )
         )
-        print("g major")
+
+    def test_g_major_scale(self):
         s = Scale([2, 2, 1, 2, 2, 2, 1], 7)  # G Major
         self.assertTrue(
             compare_scales(
@@ -162,8 +160,7 @@ class MusicUtilsTestCase(unittest.TestCase):
         )
         self.assertEqual(s.get_scale_and_octave_deltas()[1][3], 1)
 
-    def test_normalize(self):
-        print("NORMALIZE TESTS")
+    def test_normalize_pitch(self):
         self.assertTrue(normalize_pitch("C" + SHARP) == "c#")
         self.assertTrue(display_pitch("c#") == "C" + SHARP)
         self.assertTrue(strip_accidental("c#")[0] == "c")
@@ -174,7 +171,7 @@ class MusicUtilsTestCase(unittest.TestCase):
         self.assertTrue(strip_accidental("b")[0] == "b")
         self.assertTrue(strip_accidental("b")[1] == 0)
 
-        # Test normalize_scale
+    def test_normalize_scale(self):
         ks = KeySignature()
         normalized_scale = ks.normalize_scale(
             ["c", "cx", "fbb", "f", "g", "a", "b", "c"]
@@ -182,9 +179,7 @@ class MusicUtilsTestCase(unittest.TestCase):
         self.assertEqual(normalized_scale[1], "d")
         self.assertEqual(normalized_scale[2], "eb")
 
-    def test_temperament(self):
-        print("TEMPERAMENT TESTS")
-        print("equal 12")
+    def test_equal_12_temperament(self):
         t = Temperament()
         self.assertEqual(t.get_name(), "equal")
         t.set_base_frequency(t.C0)
@@ -202,32 +197,32 @@ class MusicUtilsTestCase(unittest.TestCase):
         self.assertEqual(t.get_generic_note_name_and_octave_by_freq_index(57)[0], "n9")
         self.assertEqual(t.get_generic_note_name_and_octave_by_freq_index(57)[1], 4)
 
-        print("pythagorean")
+    def test_pythagorean_temperament(self):
         t = Temperament(name="pythagorean")
         f = t.get_freqs()
         self.assertEqual(round(f[21], 100), 55.19)  # A1
         self.assertEqual(len(t.get_note_names()), 12)
 
-        print("just intonation")
+    def test_just_intonaton_temperament(self):
         t = Temperament(name="just intonation")
         f = t.get_freqs()
         self.assertEqual(round(f[21], 100), 54.51)  # A1
         self.assertEqual(len(t.get_note_names()), 12)
 
-        print("quarter comma meantone")
+    def test_quarter_comma_meantone_temperament(self):
         t = Temperament(name="quarter comma meantone")
         f = t.get_freqs()
         self.assertEqual(round(f[36], 100), 55.45)  # A1
         self.assertEqual(len(t.get_note_names()), 21)
 
-        print("equal 24")
+    def test_equal_24_temperament(self):
         t = Temperament()
         t.generate_equal_temperament(24)
         f = t.get_freqs()
         self.assertEqual(round(f[42], 100), 55.0)  # A1
         self.assertEqual(len(t.get_note_names()), 24)
 
-        print("test tuning")
+    def test_tuning(self):
         t = Temperament()
         t.tune("a", 4, 440.0)
         self.assertEqual(round(t.get_base_frequency(), 100), 16.35)
@@ -235,13 +230,21 @@ class MusicUtilsTestCase(unittest.TestCase):
         self.assertEqual(round(t.get_base_frequency(), 100), 16.39)
         self.assertEqual(round(t.get_freqs()[57], 100), 441.0)
 
+    def test_octave_ratio(self):
+        t = Temperament()
+        t.set_octave_ratio(4)
+        t.generate_equal_temperament(12)
+        f = t.get_freqs()
+        self.assertEqual(round(f[6], 100), round(f[0] * 2, 100))
+        self.assertEqual(round(f[12], 100), round(f[0] * 4, 100))
+
     def test_key_signature(self):
-        print("KEY SIGNATURE TESTS")
         ks = KeySignature(mode="major", key="c")
         self.assertEqual(ks.get_mode_length(), 7)
         self.assertEqual(ks.get_number_of_semitones(), 12)
 
-        print("closest note tests")
+    def test_closest_note(self):
+        ks = KeySignature(mode="major", key="c")
         self.assertEqual(ks.closest_note("c")[0], "c")
         self.assertTrue(ks.note_in_scale("c"))
         self.assertEqual(ks.closest_note("f#")[0], "f")
@@ -257,23 +260,28 @@ class MusicUtilsTestCase(unittest.TestCase):
         self.assertEqual(ks.closest_note("sol")[0], "sol")
         self.assertEqual(ks.closest_note("pa")[0], "pa")
 
+    def test_semitone_distance(self):
+        ks = KeySignature(mode="major", key="c")
         self.assertEqual(ks.semitone_distance("g", 4, "c", 4), -7)
         self.assertEqual(ks.semitone_distance("c", 4, "g", 4), 7)
         self.assertEqual(ks.semitone_distance("g", 3, "c", 4), 5)
         self.assertEqual(ks.semitone_distance("c", 4, "g", 3), -5)
 
+    def test_scalar_distance(self):
+        ks = KeySignature(mode="major", key="c")
         self.assertEqual(ks.scalar_distance("g", 4, "c", 4)[0], -4)
         self.assertEqual(ks.scalar_distance("c", 4, "g", 4)[0], 4)
         self.assertEqual(ks.scalar_distance("g", 3, "c", 4)[0], 3)
         self.assertEqual(ks.scalar_distance("c", 4, "g", 3)[0], -3)
 
-        # Test the scalar and semitone transforms and test for wrap around.
-        print("scalar transforms")
+    def test_scalar_transform(self):
+        ks = KeySignature(mode="major", key="c")
         self.assertEqual(ks.scalar_transform("c", 2)[0], "e")
         self.assertEqual(ks.scalar_transform("c", 2)[1], 0)  # no change to octave
         self.assertEqual(ks.scalar_transform("c#", 2)[0], "f")
 
-        print("semitone transforms")
+    def test_semitone_transform(self):
+        ks = KeySignature(mode="major", key="c")
         self.assertEqual(ks.semitone_transform("c", 2)[0], "d")
         self.assertEqual(ks.semitone_transform("c#", 2)[0], "d#")
         self.assertEqual(ks.semitone_transform("b", 1)[0], "c")
@@ -291,29 +299,26 @@ class MusicUtilsTestCase(unittest.TestCase):
 
         self.assertEqual(ks._map_to_semitone_range(13, 0)[0], 1)
 
-        print("invert transforms")
+    def test_invert_even(self):
+        ks = KeySignature(mode="major", key="c")
         self.assertEqual(ks.invert("f", 5, "c", 5, "even")[0], "g")
         self.assertEqual(ks.invert("f", 5, "c", 5, "even")[1], 4)
         self.assertEqual(ks.invert("f", 4, "c", 5, "even")[1], 5)
         self.assertEqual(ks.invert("d", 5, "c", 5, "even")[0], "a#")
+
+    def test_invert_odd(self):
+        ks = KeySignature(mode="major", key="c")
         self.assertEqual(ks.invert("f", 5, "c", 5, "odd")[0], "g#")
         self.assertEqual(ks.invert("d", 5, "c", 5, "odd")[0], "b")
+
+    def test_invert_scalar(self):
+        ks = KeySignature(mode="major", key="c")
         self.assertEqual(ks.invert("f", 5, "c", 5, "scalar")[0], "g")
         self.assertEqual(ks.invert("d", 5, "c", 5, "scalar")[0], "b")
         self.assertEqual(ks.invert("g", 5, "c", 5, "scalar")[0], "f")
         self.assertEqual(ks.invert("b", 5, "c", 5, "scalar")[0], "d")
 
-        t = Temperament()
-        self.assertEqual(
-            int(
-                t.get_freq_by_generic_note_name_and_octave(
-                    ks.convert_to_generic_note_name("a")[0], 4
-                )
-                + 0.5
-            ),
-            440,
-        )
-
+    def test_chromatic_key_signature(self):
         ks = KeySignature(mode="chromatic", key="c")
         self.assertEqual(ks.get_mode_length(), 12)
         self.assertEqual(ks.get_number_of_semitones(), 12)
@@ -322,9 +327,9 @@ class MusicUtilsTestCase(unittest.TestCase):
         self.assertEqual(ks.semitone_transform("c", 2)[0], "d")
         self.assertEqual(ks.semitone_transform("c#", 2)[0], "d#")
         self.assertEqual(ks.semitone_transform("b", 1)[0], "c")
-
         self.assertEqual(ks._map_to_scalar_range(13, 0)[0], 1)
 
+    def test_third_comma_meantone_key_signature(self):
         t = Temperament(name="third comma meantone")
         ks = KeySignature(
             key="n0",
@@ -339,8 +344,7 @@ class MusicUtilsTestCase(unittest.TestCase):
         self.assertEqual(ks.scalar_transform("n5", 2)[0], "n9")
         self.assertEqual(ks.closest_note("n10#")[0], "n11")
 
-        # Test mode equivalents
-        print("mode equivalents")
+    def test_mode_equivalents(self):
         ks = KeySignature(key="e", mode="major")
         source = ks.normalize_scale(ks.scale)
         ks = KeySignature(key="db", mode="minor")
@@ -377,8 +381,7 @@ class MusicUtilsTestCase(unittest.TestCase):
         target = ks.normalize_scale(ks.scale)
         self.assertTrue(compare_scales(source, target))
 
-        # Test Solfege mapper
-        print("solfege mapper")
+    def test_solfege_mapper(self):
         ks = KeySignature(key="c", mode="major")
         self.assertEqual(len(ks.solfege_notes), 8)
 
@@ -402,6 +405,7 @@ class MusicUtilsTestCase(unittest.TestCase):
         self.assertEqual(ks.solfege_notes[2], "re")
         self.assertEqual(ks.solfege_notes[3], "meb")
 
+    def test_convert_to_generic_note_name(self):
         ks = KeySignature()
         self.assertEqual(ks.convert_to_generic_note_name("g")[0], "n7")
         self.assertEqual(ks.convert_to_generic_note_name("sol")[0], "n7")
@@ -429,7 +433,12 @@ class MusicUtilsTestCase(unittest.TestCase):
         self.assertEqual(ks.semitone_transform("pa", 3)[0], "nib")
         self.assertEqual(ks.semitone_transform("golf", 3)[0], "n10")
 
-        print("type conversions")
+    def test_type_conversion(self):
+        ks = KeySignature()
+        ks.set_custom_note_names(
+            ["charlie", "delta", "echo", "foxtrot", "golf", "alfa", "bravo"]
+        )
+
         self.assertEqual(ks._mode_map_list(SOLFEGE_NAMES)[4], "sol")
         ks._assign_solfege_note_names()
         self.assertEqual(ks.solfege_notes[4], "sol")
@@ -460,6 +469,8 @@ class MusicUtilsTestCase(unittest.TestCase):
             ks.generic_note_name_convert_to_type("n7", CUSTOM_NAME), "golf"
         )
 
+    def test_restore_format(self):
+        ks = KeySignature()
         self.assertEqual(ks._restore_format("n7", SOLFEGE_NAME, True), "sol")
         self.assertEqual(ks._restore_format("n8", SOLFEGE_NAME, True), "sol#")
         self.assertEqual(ks._restore_format("n8", SOLFEGE_NAME, False), "lab")
@@ -469,7 +480,12 @@ class MusicUtilsTestCase(unittest.TestCase):
         # Modal pitch starts at 0
         self.assertEqual(ks.modal_pitch_to_letter(4)[0], "g")
 
-        print("pitch type check")
+    def test_pitch_type_check(self):
+        ks = KeySignature()
+        ks.set_custom_note_names(
+            ["charlie", "delta", "echo", "foxtrot", "golf", "alfa", "bravo"]
+        )
+
         self.assertEqual(ks.pitch_name_type("g"), LETTER_NAME)
         self.assertEqual(ks.pitch_name_type("c#"), LETTER_NAME)
         self.assertEqual(ks.pitch_name_type("n7"), GENERIC_NOTE_NAME)
@@ -492,8 +508,7 @@ class MusicUtilsTestCase(unittest.TestCase):
         self.assertEqual(get_pitch_type("5"), SCALAR_MODE_NUMBER)
         self.assertEqual(get_pitch_type("foobar"), UNKNOWN_PITCH_NAME)
 
-        # Test fixed Solfege
-        print("fixed solfege")
+    def test_fixed_solfege(self):
         ks = KeySignature(key="g", mode="major")
         self.assertEqual(
             ks.generic_note_name_convert_to_type("n7", SOLFEGE_NAME), "sol"
@@ -514,7 +529,20 @@ class MusicUtilsTestCase(unittest.TestCase):
         self.assertEqual(ks._generic_note_name_to_east_indian_solfege("n7")[0], "sa")
         self.assertEqual(ks._generic_note_name_to_scalar_mode_number("n7")[0], "1")
 
-        print("frequency conversion")
+    def test_get_frequency(self):
+        t = Temperament()
+        ks = KeySignature()
+        self.assertEqual(
+            int(
+                t.get_freq_by_generic_note_name_and_octave(
+                    ks.convert_to_generic_note_name("a")[0], 4
+                )
+                + 0.5
+            ),
+            440
+        )
+
+    def test_frequency_conversion(self):
         t = Temperament()
         ks = KeySignature()
         ks.set_custom_note_names(
@@ -528,7 +556,7 @@ class MusicUtilsTestCase(unittest.TestCase):
                 ),
                 100,
             ),
-            392.0,
+            392.0
         )
         self.assertEqual(
             round(
@@ -537,7 +565,7 @@ class MusicUtilsTestCase(unittest.TestCase):
                 ),
                 100,
             ),
-            392.0,
+            392.0
         )
         self.assertEqual(
             round(
@@ -546,7 +574,7 @@ class MusicUtilsTestCase(unittest.TestCase):
                 ),
                 100,
             ),
-            392.0,
+            392.0
         )
         self.assertEqual(
             round(
@@ -555,7 +583,7 @@ class MusicUtilsTestCase(unittest.TestCase):
                 ),
                 100,
             ),
-            392.0,
+            392.0
         )
         self.assertEqual(
             round(
@@ -564,10 +592,10 @@ class MusicUtilsTestCase(unittest.TestCase):
                 ),
                 100,
             ),
-            392.0,
+            392.0
         )
 
-        print("Testing meantone scales")
+    def test_meantone_scales(self):
         ks = KeySignature(mode=[], number_of_semitones=21)
         self.assertEqual(ks.get_mode_length(), 21)
         self.assertEqual(ks.get_number_of_semitones(), 21)


### PR DESCRIPTION
Three changes in separate commits:
(1) Support for octave ratio added to Temperament code
(2) Break up of unittests into more fine-grained tests: from 5 to 33.
(3) Refactoring of scale and key signature code such that much of the complexity of managing alternative naming schemes is moved to scale.py. (This could go even further if we move the closest note code into scale, which in retrospect is where it belongs.)