### PR TITLE
Add i18n utils

### DIFF
--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -19,44 +19,12 @@ var LOCALE = "en";
  * @param locale - Text to be translated.
  * @returns The translated text.
  */
-export function i18n_with_locale(original_text: string, locale: string = "en"): string {
+export function i18n(original_text: string, locale: string = "en"): string {
     // Ignore pitch numbers and pitch expressed as Hertz.
 
     var translated_text = "Not a translated phrase";
 
     let filename = 'src/i18n/lang/' + locale + '.po';
-
-    var data = require('fs').readFileSync(filename, 'utf-8');
-    var po = PO.parse(data);
-
-    for (let t in po.items) {
-        if (po.items[t].msgid === original_text) {
-            translated_text = po.items[t].msgstr[0];
-            if (translated_text === "") {
-                return original_text;
-            }
-            return translated_text;
-        }
-    }
-    return translated_text;
-}
-
-
-/**
- * Returns a translated string given its message ID.
- *
- * @remarks
- * Finds translation using the global locale variable.
- *
- * @param original_text - Message ID of text to be translated.
- * @returns The translated text.
- */
-export function i18n(original_text: string): string {
-    // Ignore pitch numbers and pitch expressed as Hertz.
-
-    var translated_text = "Not a translated phrase";
-
-    let filename = 'src/i18n/lang/' + LOCALE + '.po';
 
     var data = require('fs').readFileSync(filename, 'utf-8');
     var po = PO.parse(data);

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021, Liam Norman. All rights reserved.
+ *
+ * Licensed under the AGPL-3.0 License.
+ */
+
+
+var PO = require('pofile');
+
+var LOCALE = "en";
+
+/**
+ * Returns a translated string given its message ID and locale.
+ *
+ * @remarks
+ * None
+ *
+ * @param original_text - Text to be translated.
+ * @param locale - Text to be translated.
+ * @returns The translated text.
+ */
+export function i18n_with_locale(original_text: string, locale: string = "en"): string {
+    // Ignore pitch numbers and pitch expressed as Hertz.
+
+    var translated_text = "Not a translated phrase";
+
+    let filename = 'src/i18n/lang/' + locale + '.po';
+
+    var data = require('fs').readFileSync(filename, 'utf-8');
+    var po = PO.parse(data);
+
+    for (let t in po.items) {
+        if (po.items[t].msgid === original_text) {
+            translated_text = po.items[t].msgstr[0];
+            if (translated_text === "") {
+                return original_text;
+            }
+            return translated_text;
+        }
+    }
+    return translated_text;
+}
+
+
+/**
+ * Returns a translated string given its message ID.
+ *
+ * @remarks
+ * Finds translation using the global locale variable.
+ *
+ * @param original_text - Message ID of text to be translated.
+ * @returns The translated text.
+ */
+export function i18n(original_text: string): string {
+    // Ignore pitch numbers and pitch expressed as Hertz.
+
+    var translated_text = "Not a translated phrase";
+
+    let filename = 'src/i18n/lang/' + LOCALE + '.po';
+
+    var data = require('fs').readFileSync(filename, 'utf-8');
+    var po = PO.parse(data);
+
+    for (let t in po.items) {
+        if (po.items[t].msgid === original_text) {
+            translated_text = po.items[t].msgstr[0];
+            if (translated_text === "") {
+                return original_text;
+            }
+            return translated_text;
+        }
+    }
+    return translated_text;
+}

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -8,6 +8,33 @@
 var PO = require('pofile');
 
 var LOCALE = "en";
+var TRANSLATIONS = {};
+
+/**
+ * Loads translations dictionary given a locale.
+ *
+ * @remarks
+ * None
+ *
+ * @param locale - Locale to switch to.
+ * @returns Returns nothing, stores data in TRANSLATIONS variable.
+ */
+export function loadLocale(locale: string = "en"): void {
+
+    LOCALE = locale;
+
+    var dict = {};
+    let filename = 'src/i18n/lang/' + locale + '.po';
+    var data = require('fs').readFileSync(filename, 'utf-8');
+    var po = PO.parse(data);
+
+    for (let t in po.items) {
+        dict[po.items[t].msgid] = po.items[t].msgstr[0];
+    }
+
+    TRANSLATIONS = dict;
+}
+
 
 /**
  * Returns a translated string given its message ID and locale.
@@ -16,11 +43,27 @@ var LOCALE = "en";
  * None
  *
  * @param original_text - Text to be translated.
+ * @returns The translated text.
+ */
+export function i18n(original_text: string): string {
+    result = TRANSLATIONS[original_text];
+    if (result === null) {
+        return "";
+    }
+    return TRANSLATIONS[original_text]
+}
+
+/**
+ * Returns a translated string given its message ID and locale.
+ *
+ * @remarks
+ * Loads a po file each time func is called, so it may be better to use i18n().
+ *
+ * @param original_text - Text to be translated.
  * @param locale - Text to be translated.
  * @returns The translated text.
  */
-export function i18n(original_text: string, locale: string = "en"): string {
-    // Ignore pitch numbers and pitch expressed as Hertz.
+export function i18nPoQuery(original_text: string, locale: string = "en"): string {
 
     var translated_text = "Not a translated phrase";
 

--- a/src/i18n/lang/en.po
+++ b/src/i18n/lang/en.po
@@ -1,0 +1,15 @@
+#: i18n/tests/i18n.test.ts:1
+#~msgid "hello"
+#~msgstr ""
+
+#: i18n/tests/i18n.test.ts:1
+#~msgid "keyboard"
+#~msgstr ""
+
+#: i18n/tests/i18n.test.ts:1
+#~msgid "tempo"
+#~msgstr ""
+
+#: i18n/tests/i18n.test.ts:1
+#~msgid "note"
+#~msgstr ""

--- a/src/i18n/lang/fr.po
+++ b/src/i18n/lang/fr.po
@@ -1,0 +1,15 @@
+#: i18n/tests/i18n.test.ts:1
+#~msgid "hello"
+#~msgstr "bonjour"
+
+#: i18n/tests/i18n.test.ts:1
+#~msgid "keyboard"
+#~msgstr "clavier"
+
+#: i18n/tests/i18n.test.ts:1
+#~msgid "tempo"
+#~msgstr ""
+
+#: i18n/tests/i18n.test.ts:1
+#~msgid "note"
+#~msgstr ""

--- a/src/i18n/tests/i18n.test.ts
+++ b/src/i18n/tests/i18n.test.ts
@@ -5,18 +5,17 @@
  */
 
  import {
-     i18n,
-     i18n_with_locale
+     i18n
  } from '../i18n';
 
 describe('Internationalization utilities', () => {
     test("Query the word 'Hello' in French and recieve 'Bonjour'", () => {
-        expect(i18n_with_locale("hello", "fr")).toBe("bonjour");
+        expect(i18n("hello", "fr")).toBe("bonjour");
         // Phrases with no corresponding msgid should be detected
-        let not_translated = i18n_with_locale("Not a translated phrase", "fr");
+        let not_translated = i18n("Not a translated phrase", "fr");
         expect(not_translated).toBe("Not a translated phrase");
         // The translation of some words is is "" if they are meant to be the same as the msgid.
-        let same_as_english = i18n_with_locale("tempo", "fr");
+        let same_as_english = i18n("tempo", "fr");
         expect(same_as_english).toBe("tempo");
     });
 

--- a/src/i18n/tests/i18n.test.ts
+++ b/src/i18n/tests/i18n.test.ts
@@ -6,16 +6,19 @@
 
  import {
      i18n
+     loadLocale
  } from '../i18n';
 
 describe('Internationalization utilities', () => {
     test("Query the word 'Hello' in French and recieve 'Bonjour'", () => {
-        expect(i18n("hello", "fr")).toBe("bonjour");
+        loadLocale("fr");
+        expect(i18n("hello")).toBe("bonjour");
         // Phrases with no corresponding msgid should be detected
-        let not_translated = i18n("Not a translated phrase", "fr");
-        expect(not_translated).toBe("Not a translated phrase");
+        let not_translated = i18n("Not a translated phrase");
+        expect(not_translated).toBe("");
         // The translation of some words is is "" if they are meant to be the same as the msgid.
-        let same_as_english = i18n("tempo", "fr");
+        loadLocale("fr");
+        let same_as_english = i18n("tempo");
         expect(same_as_english).toBe("tempo");
     });
 

--- a/src/i18n/tests/i18n.test.ts
+++ b/src/i18n/tests/i18n.test.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021, Liam Norman. All rights reserved.
+ *
+ * Licensed under the AGPL-3.0 License.
+ */
+
+ import {
+     i18n,
+     i18n_with_locale
+ } from '../i18n';
+
+describe('Internationalization utilities', () => {
+    test("Query the word 'Hello' in French and recieve 'Bonjour'", () => {
+        expect(i18n_with_locale("hello", "fr")).toBe("bonjour");
+        // Phrases with no corresponding msgid should be detected
+        let not_translated = i18n_with_locale("Not a translated phrase", "fr");
+        expect(not_translated).toBe("Not a translated phrase");
+        // The translation of some words is is "" if they are meant to be the same as the msgid.
+        let same_as_english = i18n_with_locale("tempo", "fr");
+        expect(same_as_english).toBe("tempo");
+    });
+
+    test("Have 'hello' and 'note' i18n calls  be added to .po_ files", () => {
+        let hello = i18n("hello");
+        let note = i18n("note");
+        let keyboard = i18n("keyboard");
+        let tempo = i18n("tempo");
+
+    });
+});


### PR DESCRIPTION
Add the i18n() util function, which return a translation based on user's locale.
Add tests for i18n().
Add a directory with skeleton en.po and fr.po translation files.

*For testing purposes, locale is stored in a variable called LOCALE and it defaults to "en". When the app is run, this will need to be set based on the user's locale.