### PR TITLE
Syntax: Build constructs to represent syntax elements

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -11,6 +11,7 @@
   "plugins": ["@typescript-eslint"],
   "rules": {
     "@typescript-eslint/no-inferrable-types": "off",
+    "@typescript-eslint/no-empty-interface": "off",
     "no-mixed-spaces-and-tabs": "warn",
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": [

--- a/src/@types/elementsStructure.d.ts
+++ b/src/@types/elementsStructure.d.ts
@@ -4,7 +4,7 @@ export type TData = number | string | boolean;
 /** Data-type name of a value. */
 export type TDataName = 'number' | 'string' | 'boolean';
 
-/** Interface for the class that implements the syntax element. */
+/** Interface for the class that implements a syntax element. */
 export interface IElementSyntax {
     /** Name of the syntax element. */
     name: string;
@@ -20,7 +20,7 @@ export interface IElementSyntax {
     argMap: { [key: string]: TDataName[] };
 }
 
-/** Generic interface for the class that implements the argument element. */
+/** Generic interface for the class that implements an argument element. */
 export interface IElementArgument<T> extends IElementSyntax {
     /** Return types of the value returned by the argument element. */
     returnType: TDataName[];
@@ -28,7 +28,7 @@ export interface IElementArgument<T> extends IElementSyntax {
     value: T;
 }
 
-/** Generic interface for the class that implements the value element. */
+/** Generic interface for the class that implements a value element. */
 export interface IElementValue<T> extends IElementArgument<T> {
     /**
      * Updates the value stored in the value element.
@@ -37,11 +37,33 @@ export interface IElementValue<T> extends IElementArgument<T> {
     update(value: T): void;
 }
 
-/** Generic interface for the class that implements the expression element. */
+/** Generic interface for the class that implements an expression element. */
 export interface IElementExpression<T> extends IElementArgument<T> {
     /**
      * Evalutates the logic of the expression using the supplied parameters and stores the value.
      * @param params - An object containing key-value pairs of each argument and it's value
      */
     evaluate(params: { [key: string]: TData }): void;
+}
+
+/** Interface for the class that implements an instruction element. */
+export interface IElementInstruction extends IElementSyntax {
+    /**
+     * Executes the instruction using the supplied parameters.
+     * @param params - An object containing key-value pairs of each argument and it's value
+     */
+    onVisit(params: { [key: string]: TData }): void;
+}
+
+/** Interface for the class that implements a statement element. */
+export interface IElementStatement extends IElementInstruction {}
+
+/** Interface for the class that implements a block element. */
+export interface IElementBlock extends IElementInstruction {
+    /** Executes before each containing instruction is executed. */
+    onInnerVisit(): void;
+    /** Executes after each containing instruction is executed. */
+    onInnerExit(): void;
+    /** Executes after all containing instructions are executed. */
+    onExit(): void;
 }

--- a/src/@types/elementsStructure.d.ts
+++ b/src/@types/elementsStructure.d.ts
@@ -1,5 +1,8 @@
 /** Data-type of a value. */
-export type TData = 'number' | 'string' | 'boolean';
+export type TData = number | string | boolean;
+
+/** Data-type name of a value. */
+export type TDataName = 'number' | 'string' | 'boolean';
 
 /** Interface for the class that implements the syntax element. */
 export interface IElementSyntax {
@@ -15,4 +18,28 @@ export interface IElementSyntax {
     argLabels: string[];
     /** An object describing the type specification of each argument as a `argName: type[]` pair. */
     argMap: { [key: string]: TData[] };
+}
+
+/** Generic interface for the class that implements the argument element. */
+export interface IElementArgument<T> extends IElementSyntax {
+    /** Value returned by the argument element. */
+    value: T;
+}
+
+/** Generic interface for the class that implements the value element. */
+export interface IElementValue<T> extends IElementArgument<T> {
+    /**
+     * Updates the value stored in the value element.
+     * @param value - new value
+     */
+    update(value: T): void;
+}
+
+/** Generic interface for the class that implements the expression element. */
+export interface IElementExpression<T> extends IElementArgument<T> {
+    /**
+     * Evalutates the logic of the expression using the supplied parameters and stores the value.
+     * @param params - An object containing key-value pairs of each argument and it's value
+     */
+    evaluate(params: { [key: string]: TData }): void;
 }

--- a/src/@types/elementsStructure.d.ts
+++ b/src/@types/elementsStructure.d.ts
@@ -1,0 +1,18 @@
+/** Data-type of a value. */
+export type TData = 'number' | 'string' | 'boolean';
+
+/** Interface for the class that implements the syntax element. */
+export interface IElementSyntax {
+    /** Name of the syntax element. */
+    name: string;
+    /** Kind (`Argument`, `Instruction`) of the syntax element. */
+    kind: 'Argument' | 'Instruction';
+    /** Type (`Value`, `Expression`, `Statement`, `Block`) of the syntax element. */
+    type: 'Value' | 'Expression' | 'Statement' | 'Block';
+    /** Number of arguments the syntax element registers. */
+    argCount: number;
+    /** Names of the arguments the syntax element registers. */
+    argLabels: string[];
+    /** An object describing the type specification of each argument as a `argName: type[]` pair. */
+    argMap: { [key: string]: TData[] };
+}

--- a/src/@types/elementsStructure.d.ts
+++ b/src/@types/elementsStructure.d.ts
@@ -17,11 +17,13 @@ export interface IElementSyntax {
     /** Names of the arguments the syntax element registers. */
     argLabels: string[];
     /** An object describing the type specification of each argument as a `argName: type[]` pair. */
-    argMap: { [key: string]: TData[] };
+    argMap: { [key: string]: TDataName[] };
 }
 
 /** Generic interface for the class that implements the argument element. */
 export interface IElementArgument<T> extends IElementSyntax {
+    /** Return types of the value returned by the argument element. */
+    returnType: TDataName[];
     /** Value returned by the argument element. */
     value: T;
 }

--- a/src/syntax/elements/ElementArgument.spec.ts
+++ b/src/syntax/elements/ElementArgument.spec.ts
@@ -1,37 +1,68 @@
-import { TDataName } from '@/@types/elementsStructure';
-import { ElementExpression, ElementValue } from './ElementArgument';
+import { ElementArgument, ElementExpression, ElementValue } from './ElementArgument';
 
-class DummyElementValue<T> extends ElementValue<T> {
-    constructor(name: string, argMap: { [key: string]: TDataName[] }, initialValue: T) {
-        super(name, 'Value', argMap, initialValue);
-    }
-}
+class DummyElementArgument<T> extends ElementArgument<T> {}
+
+describe('class ElementArgument', () => {
+    test('instantiate class of type number that extends ElementArgument and validate returnType', () => {
+        const dummyElementArgument = new DummyElementArgument<number>(
+            'dummy',
+            'Value',
+            {},
+            ['number'],
+            0
+        );
+        expect(dummyElementArgument.returnType).toEqual(['number']);
+    });
+
+    test('instantiate class of type string that extends ElementArgument and validate returnType', () => {
+        const dummyElementArgument = new DummyElementArgument<string>(
+            'dummy',
+            'Value',
+            {},
+            ['string'],
+            'foo'
+        );
+        expect(dummyElementArgument.returnType).toEqual(['string']);
+    });
+
+    test('instantiate class of type boolean that extends ElementArgument and validate returnType', () => {
+        const dummyElementArgument = new DummyElementArgument<boolean>(
+            'dummy',
+            'Value',
+            {},
+            ['boolean'],
+            true
+        );
+        expect(dummyElementArgument.returnType).toEqual(['boolean']);
+    });
+
+    test('instantiate class of type number or string that extends ElementArgument and validate returnType', () => {
+        const dummyElementArgument = new DummyElementArgument<string | number>(
+            'dummy',
+            'Value',
+            {},
+            ['string', 'number'],
+            0
+        );
+        expect(dummyElementArgument.returnType).toEqual(['string', 'number']);
+    });
+});
+
+class DummyElementValue<T> extends ElementValue<T> {}
 
 class DummyElementValueOverrideNumber extends ElementValue<number> {
-    constructor(name: string, argMap: { [key: string]: TDataName[] }, initialValue: number) {
-        super(name, 'Value', argMap, initialValue);
-    }
-
     public get value(): number {
         return this._value * 2;
     }
 }
 
 class DummyElementValueOverrideString extends ElementValue<string> {
-    constructor(name: string, argMap: { [key: string]: TDataName[] }, initialValue: string) {
-        super(name, 'Value', argMap, initialValue);
-    }
-
     public get value(): string {
         return `foo ${this._value} bar`;
     }
 }
 
 class DummyElementValueOverrideBoolean extends ElementValue<boolean> {
-    constructor(name: string, argMap: { [key: string]: TDataName[] }, initialValue: boolean) {
-        super(name, 'Value', argMap, initialValue);
-    }
-
     public get value(): boolean {
         return !this._value;
     }
@@ -40,32 +71,72 @@ class DummyElementValueOverrideBoolean extends ElementValue<boolean> {
 describe('class ElementValue', () => {
     describe('instantiation', () => {
         test('instantiate class of type number that extends ElementValue and validate API', () => {
-            const dummyElementValueNumber1 = new DummyElementValue<number>('dummy', {}, 0);
+            const dummyElementValueNumber1 = new DummyElementValue<number>(
+                'dummy',
+                {},
+                ['number'],
+                0
+            );
             expect(dummyElementValueNumber1.value).toBe(0);
-            const dummyElementValueNumber2 = new DummyElementValue<number>('dummy', {}, 5);
+            const dummyElementValueNumber2 = new DummyElementValue<number>(
+                'dummy',
+                {},
+                ['number'],
+                5
+            );
             expect(dummyElementValueNumber2.value).toBe(5);
-            const dummyElementValueNumber3 = new DummyElementValue<number>('dummy', {}, -5);
+            const dummyElementValueNumber3 = new DummyElementValue<number>(
+                'dummy',
+                {},
+                ['number'],
+                -5
+            );
             expect(dummyElementValueNumber3.value).toBe(-5);
         });
 
         test('instantiate class of type string that extends ElementValue and validate API', () => {
-            const dummyElementValueString1 = new DummyElementValue<string>('dummy', {}, 'foo');
+            const dummyElementValueString1 = new DummyElementValue<string>(
+                'dummy',
+                {},
+                ['string'],
+                'foo'
+            );
             expect(dummyElementValueString1.value).toBe('foo');
-            const dummyElementValueString2 = new DummyElementValue<string>('dummy', {}, '');
+            const dummyElementValueString2 = new DummyElementValue<string>(
+                'dummy',
+                {},
+                ['string'],
+                ''
+            );
             expect(dummyElementValueString2.value).toBe('');
         });
 
         test('instantiate class of type boolean that extends ElementValue and validate API', () => {
-            const dummyElementValueBoolean1 = new DummyElementValue<boolean>('dummy', {}, true);
+            const dummyElementValueBoolean1 = new DummyElementValue<boolean>(
+                'dummy',
+                {},
+                ['boolean'],
+                true
+            );
             expect(dummyElementValueBoolean1.value).toBe(true);
-            const dummyElementValueBoolean2 = new DummyElementValue<boolean>('dummy', {}, false);
+            const dummyElementValueBoolean2 = new DummyElementValue<boolean>(
+                'dummy',
+                {},
+                ['boolean'],
+                false
+            );
             expect(dummyElementValueBoolean2.value).toBe(false);
         });
     });
 
     describe('update', () => {
         test('update value in instance of class of type number that extends ElementValue and validate', () => {
-            const dummyElementValueNumber = new DummyElementValue<number>('dummy', {}, 0);
+            const dummyElementValueNumber = new DummyElementValue<number>(
+                'dummy',
+                {},
+                ['number'],
+                0
+            );
             expect(dummyElementValueNumber.value).toBe(0);
             dummyElementValueNumber.update(5);
             expect(dummyElementValueNumber.value).toBe(5);
@@ -74,14 +145,24 @@ describe('class ElementValue', () => {
         });
 
         test('update value in instance of class of type string that extends ElementValue and validate', () => {
-            const dummyElementValueString = new DummyElementValue<string>('dummy', {}, '');
+            const dummyElementValueString = new DummyElementValue<string>(
+                'dummy',
+                {},
+                ['string'],
+                ''
+            );
             expect(dummyElementValueString.value).toBe('');
             dummyElementValueString.update('foo');
             expect(dummyElementValueString.value).toBe('foo');
         });
 
         test('update value in instance of class of type boolean that extends ElementValue and validate', () => {
-            const dummyElementValueBoolean = new DummyElementValue<boolean>('dummy', {}, true);
+            const dummyElementValueBoolean = new DummyElementValue<boolean>(
+                'dummy',
+                {},
+                ['boolean'],
+                true
+            );
             expect(dummyElementValueBoolean.value).toBe(true);
             dummyElementValueBoolean.update(false);
             expect(dummyElementValueBoolean.value).toBe(false);
@@ -90,7 +171,12 @@ describe('class ElementValue', () => {
 
     describe('override', () => {
         test('override value in instance of class of type number that extends ElementValue and validate', () => {
-            const dummyElementValueBoolean = new DummyElementValueOverrideNumber('dummy', {}, 5);
+            const dummyElementValueBoolean = new DummyElementValueOverrideNumber(
+                'dummy',
+                {},
+                ['number'],
+                5
+            );
             expect(dummyElementValueBoolean.value).toBe(10);
             dummyElementValueBoolean.update(-5);
             expect(dummyElementValueBoolean.value).toBe(-10);
@@ -100,6 +186,7 @@ describe('class ElementValue', () => {
             const dummyElementValueBoolean = new DummyElementValueOverrideString(
                 'dummy',
                 {},
+                ['string'],
                 'foobar'
             );
             expect(dummyElementValueBoolean.value).toBe('foo foobar bar');
@@ -111,6 +198,7 @@ describe('class ElementValue', () => {
             const dummyElementValueBoolean = new DummyElementValueOverrideBoolean(
                 'dummy',
                 {},
+                ['boolean'],
                 true
             );
             expect(dummyElementValueBoolean.value).toBe(false);
@@ -121,30 +209,18 @@ describe('class ElementValue', () => {
 });
 
 class DummyElementExpressionNumber extends ElementExpression<number> {
-    constructor(name: string, argMap: { [key: string]: TDataName[] }, initialValue: number) {
-        super(name, 'Expression', argMap, initialValue);
-    }
-
     evaluate(params: { foo: string; bar: number }): void {
         this._value = params.foo.length * params.bar;
     }
 }
 
 class DummyElementExpressionString extends ElementExpression<string> {
-    constructor(name: string, argMap: { [key: string]: TDataName[] }, initialValue: string) {
-        super(name, 'Expression', argMap, initialValue);
-    }
-
     evaluate(params: { op1: string; op2: string }): void {
         this._value = params.op1 + params.op2;
     }
 }
 
 class DummyElementExpressionBoolean extends ElementExpression<boolean> {
-    constructor(name: string, argMap: { [key: string]: TDataName[] }, initialValue: boolean) {
-        super(name, 'Expression', argMap, initialValue);
-    }
-
     evaluate(params: { op1: boolean; op2: boolean }): void {
         const { op1, op2 } = params;
         this._value = (op1 && !op2) || (!op1 && op2);
@@ -152,14 +228,6 @@ class DummyElementExpressionBoolean extends ElementExpression<boolean> {
 }
 
 class DummyElementExpressionMixed extends ElementExpression<string | number> {
-    constructor(
-        name: string,
-        argMap: { [key: string]: TDataName[] },
-        initialValue: string | number
-    ) {
-        super(name, 'Expression', argMap, initialValue);
-    }
-
     evaluate(params: { op1: string; op2: number }): void {
         const { op1, op2 } = params;
         this._value = op1.length > op2 ? op1 : op2;
@@ -168,13 +236,23 @@ class DummyElementExpressionMixed extends ElementExpression<string | number> {
 
 describe('class ElementExpression', () => {
     test('evaluate and validate instance of class that inherits ElementExpression and returns number', () => {
-        const dummyElementExpressionNumber = new DummyElementExpressionNumber('dummy', {}, 0);
+        const dummyElementExpressionNumber = new DummyElementExpressionNumber(
+            'dummy',
+            {},
+            ['number'],
+            0
+        );
         dummyElementExpressionNumber.evaluate({ foo: 'abc', bar: 5 });
         expect(dummyElementExpressionNumber.value).toBe(15);
     });
 
     test('evaluate and validate instance of class that inherits ElementExpression and returns string', () => {
-        const dummyElementExpressionString = new DummyElementExpressionString('dummy', {}, '');
+        const dummyElementExpressionString = new DummyElementExpressionString(
+            'dummy',
+            {},
+            ['string'],
+            ''
+        );
         dummyElementExpressionString.evaluate({ op1: 'foo', op2: 'bar' });
         expect(dummyElementExpressionString.value).toBe('foobar');
     });
@@ -183,6 +261,7 @@ describe('class ElementExpression', () => {
         const dummyElementExpressionNumberBoolean = new DummyElementExpressionBoolean(
             'dummy',
             {},
+            ['boolean'],
             true
         );
         dummyElementExpressionNumberBoolean.evaluate({ op1: true, op2: false });
@@ -190,10 +269,20 @@ describe('class ElementExpression', () => {
     });
 
     test('evaluate and validate instance of class that inherits ElementExpression and returns string or number', () => {
-        const dummyElementExpressionNumberMixed1 = new DummyElementExpressionMixed('dummy', {}, 0);
+        const dummyElementExpressionNumberMixed1 = new DummyElementExpressionMixed(
+            'dummy',
+            {},
+            ['string', 'number'],
+            0
+        );
         dummyElementExpressionNumberMixed1.evaluate({ op1: 'foobar', op2: 5 });
         expect(dummyElementExpressionNumberMixed1.value).toBe('foobar');
-        const dummyElementExpressionNumberMixed2 = new DummyElementExpressionMixed('dummy', {}, 0);
+        const dummyElementExpressionNumberMixed2 = new DummyElementExpressionMixed(
+            'dummy',
+            {},
+            ['string', 'number'],
+            0
+        );
         dummyElementExpressionNumberMixed2.evaluate({ op1: 'foo', op2: 5 });
         expect(dummyElementExpressionNumberMixed2.value).toBe(5);
     });

--- a/src/syntax/elements/ElementArgument.spec.ts
+++ b/src/syntax/elements/ElementArgument.spec.ts
@@ -1,0 +1,200 @@
+import { TDataName } from '@/@types/elementsStructure';
+import { ElementExpression, ElementValue } from './ElementArgument';
+
+class DummyElementValue<T> extends ElementValue<T> {
+    constructor(name: string, argMap: { [key: string]: TDataName[] }, initialValue: T) {
+        super(name, 'Value', argMap, initialValue);
+    }
+}
+
+class DummyElementValueOverrideNumber extends ElementValue<number> {
+    constructor(name: string, argMap: { [key: string]: TDataName[] }, initialValue: number) {
+        super(name, 'Value', argMap, initialValue);
+    }
+
+    public get value(): number {
+        return this._value * 2;
+    }
+}
+
+class DummyElementValueOverrideString extends ElementValue<string> {
+    constructor(name: string, argMap: { [key: string]: TDataName[] }, initialValue: string) {
+        super(name, 'Value', argMap, initialValue);
+    }
+
+    public get value(): string {
+        return `foo ${this._value} bar`;
+    }
+}
+
+class DummyElementValueOverrideBoolean extends ElementValue<boolean> {
+    constructor(name: string, argMap: { [key: string]: TDataName[] }, initialValue: boolean) {
+        super(name, 'Value', argMap, initialValue);
+    }
+
+    public get value(): boolean {
+        return !this._value;
+    }
+}
+
+describe('class ElementValue', () => {
+    describe('instantiation', () => {
+        test('instantiate class of type number that extends ElementValue and validate API', () => {
+            const dummyElementValueNumber1 = new DummyElementValue<number>('dummy', {}, 0);
+            expect(dummyElementValueNumber1.value).toBe(0);
+            const dummyElementValueNumber2 = new DummyElementValue<number>('dummy', {}, 5);
+            expect(dummyElementValueNumber2.value).toBe(5);
+            const dummyElementValueNumber3 = new DummyElementValue<number>('dummy', {}, -5);
+            expect(dummyElementValueNumber3.value).toBe(-5);
+        });
+
+        test('instantiate class of type string that extends ElementValue and validate API', () => {
+            const dummyElementValueString1 = new DummyElementValue<string>('dummy', {}, 'foo');
+            expect(dummyElementValueString1.value).toBe('foo');
+            const dummyElementValueString2 = new DummyElementValue<string>('dummy', {}, '');
+            expect(dummyElementValueString2.value).toBe('');
+        });
+
+        test('instantiate class of type boolean that extends ElementValue and validate API', () => {
+            const dummyElementValueBoolean1 = new DummyElementValue<boolean>('dummy', {}, true);
+            expect(dummyElementValueBoolean1.value).toBe(true);
+            const dummyElementValueBoolean2 = new DummyElementValue<boolean>('dummy', {}, false);
+            expect(dummyElementValueBoolean2.value).toBe(false);
+        });
+    });
+
+    describe('update', () => {
+        test('update value in instance of class of type number that extends ElementValue and validate', () => {
+            const dummyElementValueNumber = new DummyElementValue<number>('dummy', {}, 0);
+            expect(dummyElementValueNumber.value).toBe(0);
+            dummyElementValueNumber.update(5);
+            expect(dummyElementValueNumber.value).toBe(5);
+            dummyElementValueNumber.update(-5);
+            expect(dummyElementValueNumber.value).toBe(-5);
+        });
+
+        test('update value in instance of class of type string that extends ElementValue and validate', () => {
+            const dummyElementValueString = new DummyElementValue<string>('dummy', {}, '');
+            expect(dummyElementValueString.value).toBe('');
+            dummyElementValueString.update('foo');
+            expect(dummyElementValueString.value).toBe('foo');
+        });
+
+        test('update value in instance of class of type boolean that extends ElementValue and validate', () => {
+            const dummyElementValueBoolean = new DummyElementValue<boolean>('dummy', {}, true);
+            expect(dummyElementValueBoolean.value).toBe(true);
+            dummyElementValueBoolean.update(false);
+            expect(dummyElementValueBoolean.value).toBe(false);
+        });
+    });
+
+    describe('override', () => {
+        test('override value in instance of class of type number that extends ElementValue and validate', () => {
+            const dummyElementValueBoolean = new DummyElementValueOverrideNumber('dummy', {}, 5);
+            expect(dummyElementValueBoolean.value).toBe(10);
+            dummyElementValueBoolean.update(-5);
+            expect(dummyElementValueBoolean.value).toBe(-10);
+        });
+
+        test('override value in instance of class of type string that extends ElementValue and validate', () => {
+            const dummyElementValueBoolean = new DummyElementValueOverrideString(
+                'dummy',
+                {},
+                'foobar'
+            );
+            expect(dummyElementValueBoolean.value).toBe('foo foobar bar');
+            dummyElementValueBoolean.update('');
+            expect(dummyElementValueBoolean.value).toBe('foo  bar');
+        });
+
+        test('override value in instance of class of type boolean that extends ElementValue and validate', () => {
+            const dummyElementValueBoolean = new DummyElementValueOverrideBoolean(
+                'dummy',
+                {},
+                true
+            );
+            expect(dummyElementValueBoolean.value).toBe(false);
+            dummyElementValueBoolean.update(false);
+            expect(dummyElementValueBoolean.value).toBe(true);
+        });
+    });
+});
+
+class DummyElementExpressionNumber extends ElementExpression<number> {
+    constructor(name: string, argMap: { [key: string]: TDataName[] }, initialValue: number) {
+        super(name, 'Expression', argMap, initialValue);
+    }
+
+    evaluate(params: { foo: string; bar: number }): void {
+        this._value = params.foo.length * params.bar;
+    }
+}
+
+class DummyElementExpressionString extends ElementExpression<string> {
+    constructor(name: string, argMap: { [key: string]: TDataName[] }, initialValue: string) {
+        super(name, 'Expression', argMap, initialValue);
+    }
+
+    evaluate(params: { op1: string; op2: string }): void {
+        this._value = params.op1 + params.op2;
+    }
+}
+
+class DummyElementExpressionBoolean extends ElementExpression<boolean> {
+    constructor(name: string, argMap: { [key: string]: TDataName[] }, initialValue: boolean) {
+        super(name, 'Expression', argMap, initialValue);
+    }
+
+    evaluate(params: { op1: boolean; op2: boolean }): void {
+        const { op1, op2 } = params;
+        this._value = (op1 && !op2) || (!op1 && op2);
+    }
+}
+
+class DummyElementExpressionMixed extends ElementExpression<string | number> {
+    constructor(
+        name: string,
+        argMap: { [key: string]: TDataName[] },
+        initialValue: string | number
+    ) {
+        super(name, 'Expression', argMap, initialValue);
+    }
+
+    evaluate(params: { op1: string; op2: number }): void {
+        const { op1, op2 } = params;
+        this._value = op1.length > op2 ? op1 : op2;
+    }
+}
+
+describe('class ElementExpression', () => {
+    test('evaluate and validate instance of class that inherits ElementExpression and returns number', () => {
+        const dummyElementExpressionNumber = new DummyElementExpressionNumber('dummy', {}, 0);
+        dummyElementExpressionNumber.evaluate({ foo: 'abc', bar: 5 });
+        expect(dummyElementExpressionNumber.value).toBe(15);
+    });
+
+    test('evaluate and validate instance of class that inherits ElementExpression and returns string', () => {
+        const dummyElementExpressionString = new DummyElementExpressionString('dummy', {}, '');
+        dummyElementExpressionString.evaluate({ op1: 'foo', op2: 'bar' });
+        expect(dummyElementExpressionString.value).toBe('foobar');
+    });
+
+    test('evaluate and validate instance of class that inherits ElementExpression and returns boolean', () => {
+        const dummyElementExpressionNumberBoolean = new DummyElementExpressionBoolean(
+            'dummy',
+            {},
+            true
+        );
+        dummyElementExpressionNumberBoolean.evaluate({ op1: true, op2: false });
+        expect(dummyElementExpressionNumberBoolean.value).toBe(true);
+    });
+
+    test('evaluate and validate instance of class that inherits ElementExpression and returns string or number', () => {
+        const dummyElementExpressionNumberMixed1 = new DummyElementExpressionMixed('dummy', {}, 0);
+        dummyElementExpressionNumberMixed1.evaluate({ op1: 'foobar', op2: 5 });
+        expect(dummyElementExpressionNumberMixed1.value).toBe('foobar');
+        const dummyElementExpressionNumberMixed2 = new DummyElementExpressionMixed('dummy', {}, 0);
+        dummyElementExpressionNumberMixed2.evaluate({ op1: 'foo', op2: 5 });
+        expect(dummyElementExpressionNumberMixed2.value).toBe(5);
+    });
+});

--- a/src/syntax/elements/ElementArgument.ts
+++ b/src/syntax/elements/ElementArgument.ts
@@ -1,0 +1,72 @@
+import {
+    IElementArgument,
+    IElementExpression,
+    IElementValue,
+    TData,
+    TDataName
+} from '@/@types/elementsStructure';
+import { ElementSyntax } from './ElementSyntax';
+
+/**
+ * @virtual
+ * @class
+ * Generic class that defines a generic argument element.
+ *
+ * @classdesc
+ * Argument elements return a value which is either stored (value element) or evaluated (expression
+ * element) from the parameters passed. Every value element and expression element needs to extend
+ * this class.
+ */
+export abstract class ElementArgument<T> extends ElementSyntax implements IElementArgument<T> {
+    /** Stores the value this is returned by the argument element. */
+    protected _value: T;
+
+    constructor(
+        /** Name of the argument element. */
+        name: string,
+        /** Type (`Value`, `Expression`) of the argument element. */
+        type: 'Value' | 'Expression',
+        /** An object describing the type specification of each argument as a `argName: type[]` pair. */
+        argMap: { [key: string]: TDataName[] },
+        /** Initial return value of the argument. */
+        initialValue: T
+    ) {
+        super(name, 'Argument', type, argMap);
+
+        this._value = initialValue;
+    }
+
+    public get value(): T {
+        return this._value;
+    }
+}
+
+/**
+ * @virtual
+ * @class
+ * Generic class that defines a generic value element.
+ *
+ * @classdesc
+ * Value elements return a stored value.
+ */
+export abstract class ElementValue<T> extends ElementArgument<T> implements IElementValue<T> {
+    public update(value: T): void {
+        this._value = value;
+    }
+}
+
+/**
+ * @virtual
+ * @class
+ * Generic class that defines a generic expression element.
+ *
+ * @classdesc
+ * Expression elements evalutate a value based on the provided passed whose shape is in accordance
+ * with the shape of arguments it registers.
+ */
+export abstract class ElementExpression<T>
+    extends ElementArgument<T>
+    implements IElementExpression<T>
+{
+    public abstract evaluate(params: { [key: string]: TData }): void;
+}

--- a/src/syntax/elements/ElementArgument.ts
+++ b/src/syntax/elements/ElementArgument.ts
@@ -18,6 +18,8 @@ import { ElementSyntax } from './ElementSyntax';
  * this class.
  */
 export abstract class ElementArgument<T> extends ElementSyntax implements IElementArgument<T> {
+    /** Stores the return type of the value returned by the argument element. */
+    private _returnType: TDataName[];
     /** Stores the value this is returned by the argument element. */
     protected _value: T;
 
@@ -28,12 +30,19 @@ export abstract class ElementArgument<T> extends ElementSyntax implements IEleme
         type: 'Value' | 'Expression',
         /** An object describing the type specification of each argument as a `argName: type[]` pair. */
         argMap: { [key: string]: TDataName[] },
+        /** Return types of the value returned by the argument element. */
+        returnType: TDataName[],
         /** Initial return value of the argument. */
         initialValue: T
     ) {
         super(name, 'Argument', type, argMap);
 
+        this._returnType = returnType;
         this._value = initialValue;
+    }
+
+    public get returnType(): TDataName[] {
+        return this._returnType;
     }
 
     public get value(): T {
@@ -50,6 +59,19 @@ export abstract class ElementArgument<T> extends ElementSyntax implements IEleme
  * Value elements return a stored value.
  */
 export abstract class ElementValue<T> extends ElementArgument<T> implements IElementValue<T> {
+    constructor(
+        /** Name of the value element. */
+        name: string,
+        /** An object describing the type specification of each argument as a `argName: type[]` pair. */
+        argMap: { [key: string]: TDataName[] },
+        /** Return types of the value returned by the argument element. */
+        returnType: TDataName[],
+        /** Initial return value of the argument. */
+        initialValue: T
+    ) {
+        super(name, 'Value', argMap, returnType, initialValue);
+    }
+
     public update(value: T): void {
         this._value = value;
     }
@@ -68,5 +90,18 @@ export abstract class ElementExpression<T>
     extends ElementArgument<T>
     implements IElementExpression<T>
 {
+    constructor(
+        /** Name of the expression element. */
+        name: string,
+        /** An object describing the type specification of each argument as a `argName: type[]` pair. */
+        argMap: { [key: string]: TDataName[] },
+        /** Return types of the value returned by the argument element. */
+        returnType: TDataName[],
+        /** Initial return value of the argument. */
+        initialValue: T
+    ) {
+        super(name, 'Expression', argMap, returnType, initialValue);
+    }
+
     public abstract evaluate(params: { [key: string]: TData }): void;
 }

--- a/src/syntax/elements/ElementInstruction.ts
+++ b/src/syntax/elements/ElementInstruction.ts
@@ -1,0 +1,78 @@
+import {
+    IElementBlock,
+    IElementInstruction,
+    IElementStatement,
+    TData,
+    TDataName
+} from '@/@types/elementsStructure';
+import { ElementSyntax } from './ElementSyntax';
+
+/**
+ * @virtual
+ * @class
+ * Defines a generic instruction element.
+ *
+ * @classdesc
+ * Instruction elements execute logic and may operate on the parameters passed. Every statement element
+ * and block element needs to extend this class.
+ */
+export abstract class ElementInstruction extends ElementSyntax implements IElementInstruction {
+    constructor(
+        /** Name of the instruction element. */
+        name: string,
+        /** Type (`Statement`, `Block`) of the instruction element. */
+        type: 'Statement' | 'Block',
+        /** An object describing the type specification of each argument as a `argName: type[]` pair. */
+        argMap: { [key: string]: TDataName[] }
+    ) {
+        super(name, 'Instruction', type, argMap);
+    }
+
+    public abstract onVisit(params: { [key: string]: TData }): void;
+}
+
+/**
+ * @virtual
+ * @class
+ * Defines a generic statement element.
+ *
+ * @classdesc
+ * Statement elements execute one single logic.
+ */
+export abstract class ElementStatement extends ElementInstruction implements IElementStatement {
+    constructor(
+        /** Name of the statement element. */
+        name: string,
+        /** An object describing the type specification of each argument as a `argName: type[]` pair. */
+        argMap: { [key: string]: TDataName[] }
+    ) {
+        super(name, 'Statement', argMap);
+    }
+}
+
+/**
+ * @virtual
+ * @class
+ * Defines a generic block element.
+ *
+ * @classdesc
+ * Block elements encapsulate other instruction elements and set-up states prior to their execution.
+ * After the contained instruction elements have completed execution, the initial state prior to
+ * visiting the block element is restored.
+ */
+export abstract class ElementBlock extends ElementInstruction implements IElementBlock {
+    constructor(
+        /** Name of the block element. */
+        name: string,
+        /** An object describing the type specification of each argument as a `argName: type[]` pair. */
+        argMap: { [key: string]: TDataName[] }
+    ) {
+        super(name, 'Block', argMap);
+    }
+
+    public abstract onInnerVisit(): void;
+
+    public abstract onInnerExit(): void;
+
+    public abstract onExit(): void;
+}

--- a/src/syntax/elements/ElementSyntax.spec.ts
+++ b/src/syntax/elements/ElementSyntax.spec.ts
@@ -1,0 +1,69 @@
+import { TData } from '@/@types/elementsStructure';
+import { ElementSyntax } from './ElementSyntax';
+
+class DummyElementSyntax extends ElementSyntax {
+    constructor(
+        name: string,
+        kind: 'Argument' | 'Instruction',
+        type: 'Value' | 'Expression' | 'Statement' | 'Block',
+        argMap: { [key: string]: TData[] }
+    ) {
+        super(name, kind, type, argMap);
+    }
+}
+
+describe('class ElementSyntax', () => {
+    test('instantiate class that extends ElementSyntax with 0 arguments and validate API', () => {
+        let dummyElementSyntax: DummyElementSyntax;
+
+        dummyElementSyntax = new DummyElementSyntax('dummy', 'Argument', 'Value', {});
+        expect(dummyElementSyntax.name).toBe('dummy');
+        expect(dummyElementSyntax.kind).toBe('Argument');
+        expect(dummyElementSyntax.type).toBe('Value');
+        expect(dummyElementSyntax.argCount).toBe(0);
+        expect(dummyElementSyntax.argLabels).toEqual([]);
+        expect(dummyElementSyntax.argMap).toEqual({});
+
+        dummyElementSyntax = new DummyElementSyntax('dummy', 'Argument', 'Expression', {});
+        expect(dummyElementSyntax.name).toBe('dummy');
+        expect(dummyElementSyntax.kind).toBe('Argument');
+        expect(dummyElementSyntax.type).toBe('Expression');
+        expect(dummyElementSyntax.argCount).toBe(0);
+        expect(dummyElementSyntax.argLabels).toEqual([]);
+        expect(dummyElementSyntax.argMap).toEqual({});
+
+        dummyElementSyntax = new DummyElementSyntax('dummy', 'Instruction', 'Statement', {});
+        expect(dummyElementSyntax.name).toBe('dummy');
+        expect(dummyElementSyntax.kind).toBe('Instruction');
+        expect(dummyElementSyntax.type).toBe('Statement');
+        expect(dummyElementSyntax.argCount).toBe(0);
+        expect(dummyElementSyntax.argLabels).toEqual([]);
+        expect(dummyElementSyntax.argMap).toEqual({});
+
+        dummyElementSyntax = new DummyElementSyntax('dummy', 'Instruction', 'Block', {});
+        expect(dummyElementSyntax.name).toBe('dummy');
+        expect(dummyElementSyntax.kind).toBe('Instruction');
+        expect(dummyElementSyntax.type).toBe('Block');
+        expect(dummyElementSyntax.argCount).toBe(0);
+        expect(dummyElementSyntax.argLabels).toEqual([]);
+        expect(dummyElementSyntax.argMap).toEqual({});
+    });
+
+    test('instantiate class that extends ElementSyntax with 3 arguments and validate API', () => {
+        const dummyElementSyntax = new DummyElementSyntax('dummy', 'Instruction', 'Block', {
+            arg1: ['number'],
+            arg2: ['string', 'number'],
+            arg3: ['boolean']
+        });
+        expect(dummyElementSyntax.name).toBe('dummy');
+        expect(dummyElementSyntax.kind).toBe('Instruction');
+        expect(dummyElementSyntax.type).toBe('Block');
+        expect(dummyElementSyntax.argCount).toBe(3);
+        expect(dummyElementSyntax.argLabels).toEqual(['arg1', 'arg2', 'arg3']);
+        expect(dummyElementSyntax.argMap).toEqual({
+            arg1: ['number'],
+            arg2: ['string', 'number'],
+            arg3: ['boolean']
+        });
+    });
+});

--- a/src/syntax/elements/ElementSyntax.spec.ts
+++ b/src/syntax/elements/ElementSyntax.spec.ts
@@ -1,4 +1,4 @@
-import { TData } from '@/@types/elementsStructure';
+import { TDataName } from '@/@types/elementsStructure';
 import { ElementSyntax } from './ElementSyntax';
 
 class DummyElementSyntax extends ElementSyntax {
@@ -6,7 +6,7 @@ class DummyElementSyntax extends ElementSyntax {
         name: string,
         kind: 'Argument' | 'Instruction',
         type: 'Value' | 'Expression' | 'Statement' | 'Block',
-        argMap: { [key: string]: TData[] }
+        argMap: { [key: string]: TDataName[] }
     ) {
         super(name, kind, type, argMap);
     }

--- a/src/syntax/elements/ElementSyntax.ts
+++ b/src/syntax/elements/ElementSyntax.ts
@@ -1,4 +1,4 @@
-import { IElementSyntax, TData } from '@/@types/elementsStructure';
+import { IElementSyntax, TDataName } from '@/@types/elementsStructure';
 
 /**
  * @virtual
@@ -21,7 +21,7 @@ export abstract class ElementSyntax implements IElementSyntax {
     /** Stores the names of the arguments the syntax element registers. */
     private _argLabels: string[];
     /** Stores an object describing the type specification of each argument. */
-    private _argMap: { [key: string]: TData[] };
+    private _argMap: { [key: string]: TDataName[] };
 
     constructor(
         /** Name of the syntax element. */
@@ -31,7 +31,7 @@ export abstract class ElementSyntax implements IElementSyntax {
         /** Type (`Value`, `Expression`, `Statement`, `Block`) of the syntax element. */
         type: 'Value' | 'Expression' | 'Statement' | 'Block',
         /** An object describing the type specification of each argument as a `argName: type[]` pair. */
-        argMap: { [key: string]: TData[] }
+        argMap: { [key: string]: TDataName[] }
     ) {
         this._name = name;
         this._kind = kind;
@@ -61,7 +61,7 @@ export abstract class ElementSyntax implements IElementSyntax {
         return this._argLabels;
     }
 
-    public get argMap(): { [key: string]: TData[] } {
+    public get argMap(): { [key: string]: TDataName[] } {
         return this._argMap;
     }
 }

--- a/src/syntax/elements/ElementSyntax.ts
+++ b/src/syntax/elements/ElementSyntax.ts
@@ -1,0 +1,67 @@
+import { IElementSyntax, TData } from '@/@types/elementsStructure';
+
+/**
+ * @virtual
+ * @class
+ * Defines a generic syntax element and it's properties.
+ *
+ * @classdesc
+ * Syntax elements define the building blocks of a Music Blocks program. Every building block
+ * element need to inherit this class.
+ */
+export abstract class ElementSyntax implements IElementSyntax {
+    /** Stores the name of the syntax element. */
+    private _name: string;
+    /** Stores the kind of the syntax element. */
+    private _kind: 'Argument' | 'Instruction';
+    /** Stores the type of the syntax element. */
+    private _type: 'Value' | 'Expression' | 'Statement' | 'Block';
+    /** Stores the number of arguments the syntax element registers. */
+    private _argCount: number;
+    /** Stores the names of the arguments the syntax element registers. */
+    private _argLabels: string[];
+    /** Stores an object describing the type specification of each argument. */
+    private _argMap: { [key: string]: TData[] };
+
+    constructor(
+        /** Name of the syntax element. */
+        name: string,
+        /** Kind (`Argument`, `Instruction`) of the syntax element. */
+        kind: 'Argument' | 'Instruction',
+        /** Type (`Value`, `Expression`, `Statement`, `Block`) of the syntax element. */
+        type: 'Value' | 'Expression' | 'Statement' | 'Block',
+        /** An object describing the type specification of each argument as a `argName: type[]` pair. */
+        argMap: { [key: string]: TData[] }
+    ) {
+        this._name = name;
+        this._kind = kind;
+        this._type = type;
+        this._argMap = argMap;
+        this._argLabels = Object.keys(this._argMap);
+        this._argCount = this.argLabels.length;
+    }
+
+    public get name(): string {
+        return this._name;
+    }
+
+    public get kind(): 'Argument' | 'Instruction' {
+        return this._kind;
+    }
+
+    public get type(): 'Value' | 'Expression' | 'Statement' | 'Block' {
+        return this._type;
+    }
+
+    public get argCount(): number {
+        return this._argCount;
+    }
+
+    public get argLabels(): string[] {
+        return this._argLabels;
+    }
+
+    public get argMap(): { [key: string]: TData[] } {
+        return this._argMap;
+    }
+}


### PR DESCRIPTION
closes #70.

- class `ElementSyntax`
- tests for `ElementSyntax`
- class `ElementArgument`
- class `ElementValue`
- tests for `ElementValue`
- class `ElementExpression`
- tests for `ElementExpression`
- class `ElementInstruction`
- class `ElementStatement`
- class `ElementBlock`