### PR TITLE
Syntax: Rename value element to data element

### DIFF
--- a/src/@types/syntax/elementsCore.d.ts
+++ b/src/@types/syntax/elementsCore.d.ts
@@ -6,8 +6,8 @@ export interface IElementSyntax {
     name: string;
     /** Kind (`Argument`, `Instruction`) of the syntax element. */
     kind: 'Argument' | 'Instruction';
-    /** Type (`Value`, `Expression`, `Statement`, `Block`) of the syntax element. */
-    type: 'Value' | 'Expression' | 'Statement' | 'Block';
+    /** Type (`Data`, `Expression`, `Statement`, `Block`) of the syntax element. */
+    type: 'Data' | 'Expression' | 'Statement' | 'Block';
     /** Number of arguments the syntax element registers. */
     argCount: number;
     /** Names of the arguments the syntax element registers. */
@@ -24,10 +24,10 @@ export interface IElementArgument<T> extends IElementSyntax {
     value: T;
 }
 
-/** Generic interface for the class that implements a value element. */
-export interface IElementValue<T> extends IElementArgument<T> {
+/** Generic interface for the class that implements a data element. */
+export interface IElementData<T> extends IElementArgument<T> {
     /**
-     * Updates the value stored in the value element.
+     * Updates the value stored in the data element.
      * @param value - new value
      */
     update(value: T): void;

--- a/src/syntax/elements/core/elementArgument.spec.ts
+++ b/src/syntax/elements/core/elementArgument.spec.ts
@@ -1,4 +1,4 @@
-import { ElementArgument, ElementExpression, ElementValue } from './elementArgument';
+import { ElementArgument, ElementExpression, ElementData } from './elementArgument';
 
 class DummyElementArgument<T> extends ElementArgument<T> {}
 
@@ -6,7 +6,7 @@ describe('class ElementArgument', () => {
     test('instantiate class of type number that extends ElementArgument and validate returnType', () => {
         const dummyElementArgument = new DummyElementArgument<number>(
             'dummy',
-            'Value',
+            'Data',
             {},
             ['number'],
             0
@@ -17,7 +17,7 @@ describe('class ElementArgument', () => {
     test('instantiate class of type string that extends ElementArgument and validate returnType', () => {
         const dummyElementArgument = new DummyElementArgument<string>(
             'dummy',
-            'Value',
+            'Data',
             {},
             ['string'],
             'foo'
@@ -28,7 +28,7 @@ describe('class ElementArgument', () => {
     test('instantiate class of type boolean that extends ElementArgument and validate returnType', () => {
         const dummyElementArgument = new DummyElementArgument<boolean>(
             'dummy',
-            'Value',
+            'Data',
             {},
             ['boolean'],
             true
@@ -39,7 +39,7 @@ describe('class ElementArgument', () => {
     test('instantiate class of type number or string that extends ElementArgument and validate returnType', () => {
         const dummyElementArgument = new DummyElementArgument<string | number>(
             'dummy',
-            'Value',
+            'Data',
             {},
             ['string', 'number'],
             0
@@ -48,162 +48,157 @@ describe('class ElementArgument', () => {
     });
 });
 
-class DummyElementValue<T> extends ElementValue<T> {}
+class DummyElementData<T> extends ElementData<T> {}
 
-class DummyElementValueOverrideNumber extends ElementValue<number> {
+class DummyElementDataOverrideNumber extends ElementData<number> {
     public get value(): number {
         return this._value * 2;
     }
 }
 
-class DummyElementValueOverrideString extends ElementValue<string> {
+class DummyElementDataOverrideString extends ElementData<string> {
     public get value(): string {
         return `foo ${this._value} bar`;
     }
 }
 
-class DummyElementValueOverrideBoolean extends ElementValue<boolean> {
+class DummyElementDataOverrideBoolean extends ElementData<boolean> {
     public get value(): boolean {
         return !this._value;
     }
 }
 
-describe('class ElementValue', () => {
+describe('class ElementData', () => {
     describe('instantiation', () => {
-        test('instantiate class of type number that extends ElementValue and validate API', () => {
-            const dummyElementValueNumber1 = new DummyElementValue<number>(
+        test('instantiate class of type number that extends ElementData and validate API', () => {
+            const dummyElementDataNumber1 = new DummyElementData<number>(
                 'dummy',
                 {},
                 ['number'],
                 0
             );
-            expect(dummyElementValueNumber1.value).toBe(0);
-            const dummyElementValueNumber2 = new DummyElementValue<number>(
+            expect(dummyElementDataNumber1.value).toBe(0);
+            const dummyElementDataNumber2 = new DummyElementData<number>(
                 'dummy',
                 {},
                 ['number'],
                 5
             );
-            expect(dummyElementValueNumber2.value).toBe(5);
-            const dummyElementValueNumber3 = new DummyElementValue<number>(
+            expect(dummyElementDataNumber2.value).toBe(5);
+            const dummyElementDataNumber3 = new DummyElementData<number>(
                 'dummy',
                 {},
                 ['number'],
                 -5
             );
-            expect(dummyElementValueNumber3.value).toBe(-5);
+            expect(dummyElementDataNumber3.value).toBe(-5);
         });
 
-        test('instantiate class of type string that extends ElementValue and validate API', () => {
-            const dummyElementValueString1 = new DummyElementValue<string>(
+        test('instantiate class of type string that extends ElementData and validate API', () => {
+            const dummyElementDataString1 = new DummyElementData<string>(
                 'dummy',
                 {},
                 ['string'],
                 'foo'
             );
-            expect(dummyElementValueString1.value).toBe('foo');
-            const dummyElementValueString2 = new DummyElementValue<string>(
+            expect(dummyElementDataString1.value).toBe('foo');
+            const dummyElementDataString2 = new DummyElementData<string>(
                 'dummy',
                 {},
                 ['string'],
                 ''
             );
-            expect(dummyElementValueString2.value).toBe('');
+            expect(dummyElementDataString2.value).toBe('');
         });
 
-        test('instantiate class of type boolean that extends ElementValue and validate API', () => {
-            const dummyElementValueBoolean1 = new DummyElementValue<boolean>(
+        test('instantiate class of type boolean that extends ElementData and validate API', () => {
+            const dummyElementDataBoolean1 = new DummyElementData<boolean>(
                 'dummy',
                 {},
                 ['boolean'],
                 true
             );
-            expect(dummyElementValueBoolean1.value).toBe(true);
-            const dummyElementValueBoolean2 = new DummyElementValue<boolean>(
+            expect(dummyElementDataBoolean1.value).toBe(true);
+            const dummyElementDataBoolean2 = new DummyElementData<boolean>(
                 'dummy',
                 {},
                 ['boolean'],
                 false
             );
-            expect(dummyElementValueBoolean2.value).toBe(false);
+            expect(dummyElementDataBoolean2.value).toBe(false);
         });
     });
 
     describe('update', () => {
-        test('update value in instance of class of type number that extends ElementValue and validate', () => {
-            const dummyElementValueNumber = new DummyElementValue<number>(
-                'dummy',
-                {},
-                ['number'],
-                0
-            );
-            expect(dummyElementValueNumber.value).toBe(0);
-            dummyElementValueNumber.update(5);
-            expect(dummyElementValueNumber.value).toBe(5);
-            dummyElementValueNumber.update(-5);
-            expect(dummyElementValueNumber.value).toBe(-5);
+        test('update value in instance of class of type number that extends ElementData and validate', () => {
+            const dummyElementDataNumber = new DummyElementData<number>('dummy', {}, ['number'], 0);
+            expect(dummyElementDataNumber.value).toBe(0);
+            dummyElementDataNumber.update(5);
+            expect(dummyElementDataNumber.value).toBe(5);
+            dummyElementDataNumber.update(-5);
+            expect(dummyElementDataNumber.value).toBe(-5);
         });
 
-        test('update value in instance of class of type string that extends ElementValue and validate', () => {
-            const dummyElementValueString = new DummyElementValue<string>(
+        test('update value in instance of class of type string that extends ElementData and validate', () => {
+            const dummyElementDataString = new DummyElementData<string>(
                 'dummy',
                 {},
                 ['string'],
                 ''
             );
-            expect(dummyElementValueString.value).toBe('');
-            dummyElementValueString.update('foo');
-            expect(dummyElementValueString.value).toBe('foo');
+            expect(dummyElementDataString.value).toBe('');
+            dummyElementDataString.update('foo');
+            expect(dummyElementDataString.value).toBe('foo');
         });
 
-        test('update value in instance of class of type boolean that extends ElementValue and validate', () => {
-            const dummyElementValueBoolean = new DummyElementValue<boolean>(
+        test('update value in instance of class of type boolean that extends ElementData and validate', () => {
+            const dummyElementDataBoolean = new DummyElementData<boolean>(
                 'dummy',
                 {},
                 ['boolean'],
                 true
             );
-            expect(dummyElementValueBoolean.value).toBe(true);
-            dummyElementValueBoolean.update(false);
-            expect(dummyElementValueBoolean.value).toBe(false);
+            expect(dummyElementDataBoolean.value).toBe(true);
+            dummyElementDataBoolean.update(false);
+            expect(dummyElementDataBoolean.value).toBe(false);
         });
     });
 
     describe('override', () => {
-        test('override value in instance of class of type number that extends ElementValue and validate', () => {
-            const dummyElementValueBoolean = new DummyElementValueOverrideNumber(
+        test('override value in instance of class of type number that extends ElementData and validate', () => {
+            const dummyElementDataBoolean = new DummyElementDataOverrideNumber(
                 'dummy',
                 {},
                 ['number'],
                 5
             );
-            expect(dummyElementValueBoolean.value).toBe(10);
-            dummyElementValueBoolean.update(-5);
-            expect(dummyElementValueBoolean.value).toBe(-10);
+            expect(dummyElementDataBoolean.value).toBe(10);
+            dummyElementDataBoolean.update(-5);
+            expect(dummyElementDataBoolean.value).toBe(-10);
         });
 
-        test('override value in instance of class of type string that extends ElementValue and validate', () => {
-            const dummyElementValueBoolean = new DummyElementValueOverrideString(
+        test('override value in instance of class of type string that extends ElementData and validate', () => {
+            const dummyElementDataBoolean = new DummyElementDataOverrideString(
                 'dummy',
                 {},
                 ['string'],
                 'foobar'
             );
-            expect(dummyElementValueBoolean.value).toBe('foo foobar bar');
-            dummyElementValueBoolean.update('');
-            expect(dummyElementValueBoolean.value).toBe('foo  bar');
+            expect(dummyElementDataBoolean.value).toBe('foo foobar bar');
+            dummyElementDataBoolean.update('');
+            expect(dummyElementDataBoolean.value).toBe('foo  bar');
         });
 
-        test('override value in instance of class of type boolean that extends ElementValue and validate', () => {
-            const dummyElementValueBoolean = new DummyElementValueOverrideBoolean(
+        test('override value in instance of class of type boolean that extends ElementData and validate', () => {
+            const dummyElementDataBoolean = new DummyElementDataOverrideBoolean(
                 'dummy',
                 {},
                 ['boolean'],
                 true
             );
-            expect(dummyElementValueBoolean.value).toBe(false);
-            dummyElementValueBoolean.update(false);
-            expect(dummyElementValueBoolean.value).toBe(true);
+            expect(dummyElementDataBoolean.value).toBe(false);
+            dummyElementDataBoolean.update(false);
+            expect(dummyElementDataBoolean.value).toBe(true);
         });
     });
 });

--- a/src/syntax/elements/core/elementArgument.ts
+++ b/src/syntax/elements/core/elementArgument.ts
@@ -1,4 +1,4 @@
-import { IElementArgument, IElementExpression, IElementValue } from '@/@types/syntax/elementsCore';
+import { IElementArgument, IElementExpression, IElementData } from '@/@types/syntax/elementsCore';
 import { TData, TDataName } from '@/@types/syntax/data';
 import { ElementSyntax } from './elementSyntax';
 
@@ -8,8 +8,8 @@ import { ElementSyntax } from './elementSyntax';
  * Generic class that defines a generic argument element.
  *
  * @classdesc
- * Argument elements return a value which is either stored (value element) or evaluated (expression
- * element) from the parameters passed. Every value element and expression element needs to extend
+ * Argument elements return a value which is either stored (data element) or evaluated (expression
+ * element) from the parameters passed. Every data element and expression element needs to extend
  * this class.
  */
 export abstract class ElementArgument<T> extends ElementSyntax implements IElementArgument<T> {
@@ -21,8 +21,8 @@ export abstract class ElementArgument<T> extends ElementSyntax implements IEleme
     constructor(
         /** Name of the argument element. */
         name: string,
-        /** Type (`Value`, `Expression`) of the argument element. */
-        type: 'Value' | 'Expression',
+        /** Type (`Data`, `Expression`) of the argument element. */
+        type: 'Data' | 'Expression',
         /** An object describing the type specification of each argument as a `argName: type[]` pair. */
         argMap: { [key: string]: TDataName[] },
         /** Return types of the value returned by the argument element. */
@@ -48,14 +48,14 @@ export abstract class ElementArgument<T> extends ElementSyntax implements IEleme
 /**
  * @virtual
  * @class
- * Generic class that defines a generic value element.
+ * Generic class that defines a generic data element.
  *
  * @classdesc
- * Value elements return a stored value.
+ * Data elements return a stored value.
  */
-export abstract class ElementValue<T> extends ElementArgument<T> implements IElementValue<T> {
+export abstract class ElementData<T> extends ElementArgument<T> implements IElementData<T> {
     constructor(
-        /** Name of the value element. */
+        /** Name of the data element. */
         name: string,
         /** An object describing the type specification of each argument as a `argName: type[]` pair. */
         argMap: { [key: string]: TDataName[] },
@@ -64,7 +64,7 @@ export abstract class ElementValue<T> extends ElementArgument<T> implements IEle
         /** Initial return value of the argument. */
         initialValue: T
     ) {
-        super(name, 'Value', argMap, returnType, initialValue);
+        super(name, 'Data', argMap, returnType, initialValue);
     }
 
     public update(value: T): void {

--- a/src/syntax/elements/core/elementSyntax.spec.ts
+++ b/src/syntax/elements/core/elementSyntax.spec.ts
@@ -5,7 +5,7 @@ class DummyElementSyntax extends ElementSyntax {
     constructor(
         name: string,
         kind: 'Argument' | 'Instruction',
-        type: 'Value' | 'Expression' | 'Statement' | 'Block',
+        type: 'Data' | 'Expression' | 'Statement' | 'Block',
         argMap: { [key: string]: TDataName[] }
     ) {
         super(name, kind, type, argMap);
@@ -16,10 +16,10 @@ describe('class ElementSyntax', () => {
     test('instantiate class that extends ElementSyntax with 0 arguments and validate API', () => {
         let dummyElementSyntax: DummyElementSyntax;
 
-        dummyElementSyntax = new DummyElementSyntax('dummy', 'Argument', 'Value', {});
+        dummyElementSyntax = new DummyElementSyntax('dummy', 'Argument', 'Data', {});
         expect(dummyElementSyntax.name).toBe('dummy');
         expect(dummyElementSyntax.kind).toBe('Argument');
-        expect(dummyElementSyntax.type).toBe('Value');
+        expect(dummyElementSyntax.type).toBe('Data');
         expect(dummyElementSyntax.argCount).toBe(0);
         expect(dummyElementSyntax.argLabels).toEqual([]);
         expect(dummyElementSyntax.argMap).toEqual({});

--- a/src/syntax/elements/core/elementSyntax.ts
+++ b/src/syntax/elements/core/elementSyntax.ts
@@ -16,7 +16,7 @@ export abstract class ElementSyntax implements IElementSyntax {
     /** Stores the kind of the syntax element. */
     private _kind: 'Argument' | 'Instruction';
     /** Stores the type of the syntax element. */
-    private _type: 'Value' | 'Expression' | 'Statement' | 'Block';
+    private _type: 'Data' | 'Expression' | 'Statement' | 'Block';
     /** Stores the number of arguments the syntax element registers. */
     private _argCount: number;
     /** Stores the names of the arguments the syntax element registers. */
@@ -29,8 +29,8 @@ export abstract class ElementSyntax implements IElementSyntax {
         name: string,
         /** Kind (`Argument`, `Instruction`) of the syntax element. */
         kind: 'Argument' | 'Instruction',
-        /** Type (`Value`, `Expression`, `Statement`, `Block`) of the syntax element. */
-        type: 'Value' | 'Expression' | 'Statement' | 'Block',
+        /** Type (`Data`, `Expression`, `Statement`, `Block`) of the syntax element. */
+        type: 'Data' | 'Expression' | 'Statement' | 'Block',
         /** An object describing the type specification of each argument as a `argName: type[]` pair. */
         argMap: { [key: string]: TDataName[] }
     ) {
@@ -50,7 +50,7 @@ export abstract class ElementSyntax implements IElementSyntax {
         return this._kind;
     }
 
-    public get type(): 'Value' | 'Expression' | 'Statement' | 'Block' {
+    public get type(): 'Data' | 'Expression' | 'Statement' | 'Block' {
         return this._type;
     }
 


### PR DESCRIPTION
Renames `ElementValue` to `ElementData` and all literal references of value element to data element.

closes #80.