### PR TITLE
Syntax: [feat] Create syntax element warehouse with tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,15 @@
       "license": "AGPL-3.0",
       "devDependencies": {
         "@types/jest": "^26.0.19",
+        "@types/uuid": "^8.3.1",
         "@typescript-eslint/eslint-plugin": "^4.11.1",
         "@typescript-eslint/parser": "^4.11.1",
         "eslint": "^7.17.0",
         "eslint-config-prettier": "^7.1.0",
         "jest": "^26.6.3",
         "ts-jest": "^26.4.4",
-        "typescript": "^4.1.3"
+        "typescript": "^4.1.3",
+        "uuid": "^8.3.2"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1149,6 +1151,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -6834,7 +6842,6 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true,
-      "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -8018,6 +8025,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+      "dev": true
+    },
+    "@types/uuid": {
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-Y2mHTRAbqfFkpjldbkHGY8JIzRN6XqYRliG8/24FcHm2D2PwW24fl5xMRTVGdrb7iMrwCaIEbLWerGIkXuFWVg==",
       "dev": true
     },
     "@types/yargs": {
@@ -12382,8 +12395,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -16,13 +16,15 @@
   "types": "dist",
   "devDependencies": {
     "@types/jest": "^26.0.19",
+    "@types/uuid": "^8.3.1",
     "@typescript-eslint/eslint-plugin": "^4.11.1",
     "@typescript-eslint/parser": "^4.11.1",
     "eslint": "^7.17.0",
     "eslint-config-prettier": "^7.1.0",
     "jest": "^26.6.3",
     "ts-jest": "^26.4.4",
-    "typescript": "^4.1.3"
+    "typescript": "^4.1.3",
+    "uuid": "^8.3.2"
   },
   "scripts": {
     "build": "rm -rf dist/* && tsc -p .",

--- a/src/@types/syntax/elementSpecification.d.ts
+++ b/src/@types/syntax/elementSpecification.d.ts
@@ -1,6 +1,11 @@
 import { TData } from './data';
 import { IElementData, IElementExpression, IElementStatement, IElementBlock } from './elementsCore';
 
+/** Kind (`Argument`, `Instruction`) of the syntax element. */
+export type TElementKind = 'Argument' | 'Instruction';
+/** Type (`Data`, `Expression`, `Statement`, `Block`) of the syntax element. */
+export type TElementType = 'Data' | 'Expression' | 'Statement' | 'Block';
+
 export type TElementCategoryData = 'value' | 'boxidentifier';
 export type TElementCategoryExpression = 'operator-math';
 export type TElementCategoryStatement = 'box';

--- a/src/@types/syntax/elementsCore.d.ts
+++ b/src/@types/syntax/elementsCore.d.ts
@@ -1,5 +1,5 @@
 import { TData, TDataName } from './data';
-import { TElementName } from './elementSpecification';
+import { TElementName, TElementKind, TElementType } from './elementSpecification';
 
 /** Interface for the class that implements a syntax element. */
 export interface IElementSyntax {
@@ -8,9 +8,9 @@ export interface IElementSyntax {
     /** Display name of the syntax element. */
     label: string;
     /** Kind (`Argument`, `Instruction`) of the syntax element. */
-    kind: 'Argument' | 'Instruction';
+    kind: TElementKind;
     /** Type (`Data`, `Expression`, `Statement`, `Block`) of the syntax element. */
-    type: 'Data' | 'Expression' | 'Statement' | 'Block';
+    type: TElementType;
     /** Number of arguments the syntax element registers. */
     argCount: number;
     /** Names of the arguments the syntax element registers. */

--- a/src/syntax/elements/warehouse.spec.ts
+++ b/src/syntax/elements/warehouse.spec.ts
@@ -1,0 +1,186 @@
+import { ElementBlock } from './core/elementInstruction';
+import { ElementBoxBoolean } from './program/boxes/elementBox';
+import { ElementOperatorMathPlus } from './program/operators/elementOperatorMath';
+import { ElementValueBoolean } from './program/values/elementValue';
+import {
+    addInstance,
+    getInstance,
+    removeInstance,
+    getNameCount,
+    getNameCountAll,
+    getKindCount,
+    getKindCountAll,
+    getTypeCount,
+    getTypeCountAll,
+    getCategoryCount,
+    getCategoryCountAll,
+    resetWarehouse
+} from './warehouse';
+
+describe('Syntax Element Warehouse', () => {
+    let instanceID1: string;
+    let instanceID2: string;
+    let instanceID3: string;
+    let instanceID4: string;
+
+    describe('adding instance', () => {
+        test('add an instance of a data element', () => {
+            instanceID1 = addInstance('value-boolean');
+            expect(typeof instanceID1).toBe('string');
+        });
+
+        test('add an instance of an expression element', () => {
+            instanceID2 = addInstance('operator-math-plus');
+            expect(typeof instanceID2).toBe('string');
+        });
+
+        test('add an instance of a statement element', () => {
+            instanceID3 = addInstance('box-boolean');
+            expect(typeof instanceID3).toBe('string');
+        });
+
+        test('add an instance of a block element', () => {
+            instanceID4 = addInstance('block-dummy');
+            expect(typeof instanceID4).toBe('string');
+        });
+    });
+
+    describe('fetching instance', () => {
+        test('fetch instance with invalid instance ID and expect null', () => {
+            expect(getInstance(instanceID1 + '00')).toBe(null);
+        });
+
+        test('fetch instance of a data element with valid instance ID and verify', () => {
+            const { name, kind, type, category, instance } = getInstance(instanceID1)!;
+            expect(name).toBe('value-boolean');
+            expect(kind).toBe('Argument');
+            expect(type).toBe('Data');
+            expect(category).toBe('value');
+            expect(instance instanceof ElementValueBoolean);
+        });
+
+        test('fetch instance of an expression element with valid instance ID and verify', () => {
+            const { name, kind, type, category, instance } = getInstance(instanceID2)!;
+            expect(name).toBe('operator-math-plus');
+            expect(kind).toBe('Argument');
+            expect(type).toBe('Expression');
+            expect(category).toBe('operator-math');
+            expect(instance instanceof ElementOperatorMathPlus);
+        });
+
+        test('fetch instance of a statement element with valid instance ID and verify', () => {
+            const { name, kind, type, category, instance } = getInstance(instanceID3)!;
+            expect(name).toBe('box-boolean');
+            expect(kind).toBe('Instruction');
+            expect(type).toBe('Statement');
+            expect(category).toBe('box');
+            expect(instance instanceof ElementBoxBoolean);
+        });
+
+        test('fetch instance of a block element with valid instance ID and verify', () => {
+            const { name, kind, type, category, instance } = getInstance(instanceID4)!;
+            expect(name).toBe('block-dummy');
+            expect(kind).toBe('Instruction');
+            expect(type).toBe('Block');
+            expect(category).toBe('block-dummy');
+            expect(instance instanceof ElementBlock);
+        });
+    });
+
+    describe('get stats', () => {
+        addInstance('value-boolean');
+        addInstance('boxidentifier-boolean');
+        addInstance('operator-math-divide');
+        addInstance('box-number');
+
+        test('verify name count', () => {
+            expect(getNameCount('value-boolean')).toBe(2);
+            expect(getNameCount('value-number')).toBe(0);
+        });
+
+        test('verify kind count', () => {
+            expect(getKindCount('Argument')).toBe(5);
+            expect(getKindCount('Instruction')).toBe(3);
+        });
+
+        test('verify kind count all', () => {
+            expect(new Set(Object.entries(getKindCountAll()))).toEqual(
+                new Set([
+                    ['Argument', 5],
+                    ['Instruction', 3]
+                ])
+            );
+        });
+
+        test('verify type count', () => {
+            expect(getTypeCount('Data')).toBe(3);
+            expect(getTypeCount('Expression')).toBe(2);
+            expect(getTypeCount('Statement')).toBe(2);
+            expect(getTypeCount('Block')).toBe(1);
+        });
+
+        test('verify type count all', () => {
+            expect(new Set(Object.entries(getTypeCountAll()))).toEqual(
+                new Set([
+                    ['Data', 3],
+                    ['Expression', 2],
+                    ['Statement', 2],
+                    ['Block', 1]
+                ])
+            );
+        });
+
+        test('verify category count', () => {
+            expect(getCategoryCount('value')).toBe(2);
+            expect(getCategoryCount('boxidentifier')).toBe(1);
+            expect(getCategoryCount('operator-math')).toBe(2);
+            expect(getCategoryCount('box')).toBe(2);
+            expect(getCategoryCount('block-dummy')).toBe(1);
+        });
+
+        test('verify category count all', () => {
+            expect(new Set(Object.entries(getCategoryCountAll()))).toEqual(
+                new Set([
+                    ['value', 2],
+                    ['boxidentifier', 1],
+                    ['operator-math', 2],
+                    ['box', 2],
+                    ['block-dummy', 1]
+                ])
+            );
+        });
+    });
+
+    describe('removing instance', () => {
+        test('remove an existing instance ID and verify', () => {
+            removeInstance(instanceID1);
+            expect(getInstance(instanceID1)).toBe(null);
+            expect(getNameCount('value-boolean')).toBe(1);
+            expect(getKindCount('Argument')).toBe(4);
+            expect(getKindCount('Instruction')).toBe(3);
+            expect(getTypeCount('Data')).toBe(2);
+            expect(getTypeCount('Expression')).toBe(2);
+            expect(getTypeCount('Statement')).toBe(2);
+            expect(getTypeCount('Block')).toBe(1);
+            expect(getCategoryCount('value')).toBe(1);
+            expect(getCategoryCount('boxidentifier')).toBe(1);
+            expect(getCategoryCount('operator-math')).toBe(2);
+            expect(getCategoryCount('box')).toBe(2);
+            expect(getCategoryCount('block-dummy')).toBe(1);
+        });
+    });
+
+    describe('reset', () => {
+        function _checkEmpty(table: { [key: string]: number }): boolean {
+            return Object.values(table).reduce((a, b) => a + b) === 0;
+        }
+
+        test('reset warehouse and verify from stats', () => {
+            resetWarehouse();
+            expect(_checkEmpty(getNameCountAll())).toBe(true);
+            expect(_checkEmpty(getKindCountAll())).toBe(true);
+            expect(_checkEmpty(getTypeCountAll())).toBe(true);
+            expect(_checkEmpty(getCategoryCountAll())).toBe(true);
+        });
+    });
+});

--- a/src/syntax/elements/warehouse.ts
+++ b/src/syntax/elements/warehouse.ts
@@ -1,0 +1,328 @@
+import { v4 as uuidv4 } from 'uuid';
+
+import {
+    TElementName,
+    TElementKind,
+    TElementType,
+    TElementCategory,
+    TElementCategoryData,
+    TElementCategoryExpression,
+    TElementCategoryStatement,
+    TElementCategoryBlock,
+    TElementDataName,
+    TElementExpressionName,
+    TElementStatementName,
+    TElementBlockName
+} from '@/@types/syntax/elementSpecification';
+import elementSpecification from './specification';
+
+import { TData } from '@/@types/syntax/data';
+import { ElementSyntax } from './core/elementSyntax';
+import { ElementData, ElementExpression } from './core/elementArgument';
+import { ElementStatement, ElementBlock } from './core/elementInstruction';
+
+abstract class ElementDataCover extends ElementData<TData> {}
+abstract class ElementExpressionCover extends ElementExpression<TData> {}
+
+/** Stores the count of element name. */
+let _elementNameCountMap: { [elementName: string]: number } = {};
+/** Stores the count of element kind. */
+let _elementKindCountMap: { [elementKind: string]: number } = {};
+/** Stores the count of element type. */
+let _elementTypeCountMap: { [elementKind: string]: number } = {};
+/** Stores the count of element category. */
+let _elementCategoryCountMap: { [elementKind: string]: number } = {};
+
+/** Stores an extensive table of element name, kind, type, category, instance, by instance ID. */
+let _elementMap: {
+    [elementID: string]:
+        | {
+              instance: ElementDataCover;
+              type: 'Data';
+              name: TElementDataName;
+              kind: 'Argument';
+              category: TElementCategoryData;
+          }
+        | {
+              instance: ElementExpressionCover;
+              type: 'Expression';
+              name: TElementExpressionName;
+              kind: 'Argument';
+              category: TElementCategoryExpression;
+          }
+        | {
+              instance: ElementStatement;
+              type: 'Statement';
+              name: TElementStatementName;
+              kind: 'Instruction';
+              category: TElementCategoryStatement;
+          }
+        | {
+              instance: ElementBlock;
+              type: 'Block';
+              name: TElementBlockName;
+              kind: 'Instruction';
+              category: TElementCategoryBlock;
+          };
+} = {};
+
+/**
+ * Helper function that creates a new instance, adds to element table, and updates count tables.
+ * @param elementName - name of the element
+ * @param instanceID - key for entry in element table
+ * @param instance - element instance
+ * @param type - type of the element
+ * @param category - category of the element
+ */
+function _addInstance(
+    elementName: TElementName,
+    instanceID: string,
+    instance: ElementSyntax,
+    type: TElementType,
+    category: TElementCategory
+): void {
+    const kind = type === 'Data' || type === 'Expression' ? 'Argument' : 'Instruction';
+
+    switch (type) {
+        case 'Data':
+            _elementMap[instanceID] = {
+                instance: instance as ElementDataCover,
+                name: elementName as TElementDataName,
+                type: type as 'Data',
+                kind: 'Argument',
+                category: category as TElementCategoryData
+            };
+            break;
+        case 'Expression':
+            _elementMap[instanceID] = {
+                instance: instance as ElementExpressionCover,
+                name: elementName as TElementExpressionName,
+                type: type as 'Expression',
+                kind: 'Argument',
+                category: category as TElementCategoryExpression
+            };
+            break;
+        case 'Statement':
+            _elementMap[instanceID] = {
+                instance: instance as ElementStatement,
+                name: elementName as TElementStatementName,
+                type: type as 'Statement',
+                kind: 'Instruction',
+                category: category as TElementCategoryStatement
+            };
+            break;
+        case 'Block':
+            _elementMap[instanceID] = {
+                instance: instance as ElementBlock,
+                name: elementName as TElementBlockName,
+                type: type as 'Block',
+                kind: 'Instruction',
+                category: category as TElementCategoryBlock
+            };
+            break;
+    }
+
+    _elementNameCountMap[elementName]++;
+    _elementKindCountMap[kind]++;
+    _elementTypeCountMap[type]++;
+    _elementCategoryCountMap[category]++;
+}
+
+/**
+ * Creates a new instance, adds to element table, and updates count tables.
+ * @param elementName - name of the element
+ * @returns - unique instance ID for the element instance
+ */
+export function addInstance(elementName: TElementName): string {
+    const { label, type, category, prototype } = elementSpecification[elementName];
+
+    let instance: ElementSyntax;
+
+    switch (type) {
+        case 'Data':
+            instance = (prototype as (name: TElementDataName, label: string) => ElementDataCover)(
+                elementName as TElementDataName,
+                label
+            );
+            break;
+        case 'Expression':
+            instance = (
+                prototype as (name: TElementExpressionName, label: string) => ElementExpressionCover
+            )(elementName as TElementExpressionName, label);
+            break;
+        case 'Statement':
+            instance = (
+                prototype as (name: TElementStatementName, label: string) => ElementStatement
+            )(elementName as TElementStatementName, label);
+            break;
+        case 'Block':
+            instance = (prototype as (name: TElementBlockName, label: string) => ElementBlock)(
+                elementName as TElementBlockName,
+                label
+            );
+    }
+
+    let instanceID: string;
+    do {
+        instanceID = uuidv4();
+    } while (instanceID in _elementMap);
+
+    _addInstance(elementName, instanceID, instance, type, category);
+
+    return instanceID;
+}
+
+/**
+ * Fetches the element instance entry from element table.
+ * @param instanceID - instance ID of the element in element table
+ * @returns element instance with additional properties
+ */
+export function getInstance(instanceID: string): {
+    name: TElementName;
+    kind: TElementKind;
+    type: TElementType;
+    category: TElementCategory;
+    instance: ElementSyntax;
+} | null {
+    return instanceID in _elementMap ? { ..._elementMap[instanceID] } : null;
+}
+
+/**
+ * Removes the element entry corresponding to the instance ID and updates count tables.
+ * @param instanceID - instance ID of the element in element table
+ */
+export function removeInstance(instanceID: string): void {
+    if (!(instanceID in _elementMap)) {
+        return;
+    }
+
+    const { name, kind, type, category } = _elementMap[instanceID];
+    _elementNameCountMap[name]--;
+    _elementKindCountMap[kind]--;
+    _elementTypeCountMap[type]--;
+    _elementCategoryCountMap[category]--;
+    delete _elementMap[instanceID];
+}
+
+/**
+ * Returns the number of element instances of an element name exists in element table.
+ * @param name - name of the element
+ * @returns count of the element instances for the element name
+ */
+export function getNameCount(name: TElementName): number {
+    return _elementNameCountMap[name];
+}
+
+/**
+ * Generates a table of element instance counts by element name.
+ * @returns an object with key-value pairs of element name and instance count
+ */
+export function getNameCountAll(): { [name: string]: number } {
+    return { ..._elementNameCountMap };
+}
+
+/**
+ * Returns the number of element instances of an element kind exists in element table.
+ * @param kind - kind of the element
+ * @returns count of the element instances for the element kind
+ */
+export function getKindCount(kind: TElementKind): number {
+    return _elementKindCountMap[kind];
+}
+
+/**
+ * Generates a table of element instance counts by element kind.
+ * @returns an object with key-value pairs of element kind and instance count
+ */
+export function getKindCountAll(): { [kind: string]: number } {
+    return { ..._elementKindCountMap };
+}
+
+/**
+ * Returns the number of element instances of an element type exists in element table.
+ * @param type - type of the element
+ * @returns count of the element instances for the element type
+ */
+export function getTypeCount(type: TElementType): number {
+    return _elementTypeCountMap[type];
+}
+
+/**
+ * Generates a table of element instance counts by element type.
+ * @returns an object with key-value pairs of element type and instance count
+ */
+export function getTypeCountAll(): { [type: string]: number } {
+    return { ..._elementTypeCountMap };
+}
+
+/**
+ * Returns the number of element instances of an element category exists in element table.
+ * @param category - category of the element
+ * @returns count of the element instances for the element category
+ */
+export function getCategoryCount(category: TElementCategory): number {
+    return _elementCategoryCountMap[category];
+}
+
+/**
+ * Generates a table of element instance counts by element category.
+ * @returns an object with key-value pairs of element category and instance count
+ */
+export function getCategoryCountAll(): { [category: string]: number } {
+    return { ..._elementCategoryCountMap };
+}
+
+/**
+ * Helper that resets the element name count table.
+ */
+function _resetElementNameCountMap(): void {
+    _elementNameCountMap = {};
+    (Object.keys(elementSpecification) as TElementName[]).forEach(
+        (elementName) => (_elementNameCountMap[elementName] = 0)
+    );
+}
+
+/**
+ * Helper that resets the element kind count table.
+ */
+function _resetElementKindCountMap(): void {
+    _elementKindCountMap = {
+        Argument: 0,
+        Instruction: 0
+    };
+}
+
+/**
+ * Helper that resets the element type count table.
+ */
+function _resetElementTypeCountMap(): void {
+    _elementTypeCountMap = {
+        Data: 0,
+        Expression: 0,
+        Statement: 0,
+        Block: 0
+    };
+}
+
+/**
+ * Helper that resets the element category count table.
+ */
+function _resetElementCategoryCountMap(): void {
+    _elementCategoryCountMap = {};
+    const categorySet = new Set<TElementCategory>();
+    Object.entries(elementSpecification).forEach(([_, { category }]) => categorySet.add(category));
+    [...categorySet].forEach((category) => (_elementCategoryCountMap[category] = 0));
+}
+
+/**
+ * Resets all the count tables and element map.
+ */
+export function resetWarehouse(): void {
+    _elementMap = {};
+    _resetElementNameCountMap();
+    _resetElementKindCountMap();
+    _resetElementTypeCountMap();
+    _resetElementCategoryCountMap();
+}
+
+resetWarehouse();


### PR DESCRIPTION
- add an element instance
- get an element instance
- remove an element instance
- get count of element instances for an element name
- get count of element instances for all element names
- get count of element instances for an element kind
- get count of element instances for all element kinds
- get count of element instances for an element type
- get count of element instances for all element types
- get count of element instances for an element category
- get count of element instances for all element categories
- reset the warehouse

closes #74.