### PR TITLE
Syntax Tree: [snapshot] Pack node ID

### DIFF
--- a/src/@types/syntaxTree.d.ts
+++ b/src/@types/syntaxTree.d.ts
@@ -8,36 +8,81 @@ import {
 
 // -- snapshots ------------------------------------------------------------------------------------
 
-/** Type definition for the snapshot of a data element. */
-export interface ITreeSnapshotData {
+/** Type definition for the snapshot input of a data element. */
+export interface ITreeSnapshotDataInput {
     /** Name of the data element. */
     elementName: TElementNameData;
 }
 
-/** Type definition for the snapshot of an expression element. */
-export interface ITreeSnapshotExpression {
+/** Type definition for the snapshot of a data element. */
+export interface ITreeSnapshotData extends ITreeSnapshotDataInput {
+    /** Node ID of the syntax tree node instance. */
+    nodeID: string;
+}
+
+/** Type definition for the snapshot input of an expression element. */
+export interface ITreeSnapshotExpressionInput {
     /** Name of the expression element. */
     elementName: TElementNameExpression;
     /** Object with key-value pairs of argument name and snapshot of the corresponding argument. */
-    argMap: { [argName: string]: ITreeSnapshotData | ITreeSnapshotExpression | null } | null;
+    argMap: {
+        [argName: string]: ITreeSnapshotDataInput | ITreeSnapshotExpressionInput | null;
+    } | null;
 }
 
-/** Type definition for the snapshot of a statement element. */
-export interface ITreeSnapshotStatement {
+/** Type definition for the snapshot of an expression element. */
+export interface ITreeSnapshotExpression extends ITreeSnapshotExpressionInput {
+    /** Node ID of the syntax tree node instance. */
+    nodeID: string;
+}
+
+/** Type definition for the snapshot input of a statement element. */
+export interface ITreeSnapshotStatementInput {
     /** Name of the statement element. */
     elementName: TElementNameStatement;
     /** Object with key-value pairs of argument name and snapshot of the corresponding argument. */
-    argMap: { [argName: string]: ITreeSnapshotData | ITreeSnapshotExpression | null } | null;
+    argMap: {
+        [argName: string]: ITreeSnapshotDataInput | ITreeSnapshotExpressionInput | null;
+    } | null;
 }
 
-/** Type definition for the snapshot of a block element. */
-export interface ITreeSnapshotBlock {
+/** Type definition for the snapshot of a statement element. */
+export interface ITreeSnapshotStatement extends ITreeSnapshotStatementInput {
+    /** Node ID of the syntax tree node instance. */
+    nodeID: string;
+}
+
+/** Type definition for the snapshot input of a block element. */
+export interface ITreeSnapshotBlockInput {
     /** Name of the block element. */
     elementName: TElementNameBlock;
     /** Object with key-value pairs of argument name and snapshot of the corresponding argument. */
-    argMap: { [argName: string]: ITreeSnapshotData | ITreeSnapshotExpression | null } | null;
+    argMap: {
+        [argName: string]: ITreeSnapshotDataInput | ITreeSnapshotExpressionInput | null;
+    } | null;
     /** List of snaphots of the elements nested in the block. */
-    scope: (ITreeSnapshotStatement | ITreeSnapshotBlock)[];
+    scope: (ITreeSnapshotStatementInput | ITreeSnapshotBlockInput)[];
+}
+
+/** Type definition for the snapshot of a block element. */
+export interface ITreeSnapshotBlock extends ITreeSnapshotBlockInput {
+    /** Node ID of the syntax tree node instance. */
+    nodeID: string;
+}
+
+/** Type definition for the snapshot input of the entire syntax tree. */
+export interface ITreeSnapshotInput {
+    /** List of snapshot inputs of all process elements. */
+    process: ITreeSnapshotBlockInput[];
+    /** List of snapshot inputs of all routine elements. */
+    routine: ITreeSnapshotBlockInput[];
+    /** List of snapshot input lists of all non-process and non-routine element stacks. */
+    crumbs: (
+        | ITreeSnapshotDataInput
+        | ITreeSnapshotExpressionInput
+        | ITreeSnapshotStatementInput
+        | ITreeSnapshotBlockInput
+    )[][];
 }
 
 /** Type definition for the snapshot of the entire syntax tree. */

--- a/src/syntax/tree/node.ts
+++ b/src/syntax/tree/node.ts
@@ -132,6 +132,7 @@ export class TreeNodeData extends TreeNodeArgument implements ITreeNodeData {
     public get snapshot(): ITreeSnapshotData {
         return {
             elementName: this._elementName as TElementNameData,
+            nodeID: this._nodeID,
         };
     }
 }
@@ -148,6 +149,7 @@ export class TreeNodeExpression extends TreeNodeArgument implements ITreeNodeExp
     public get snapshot(): ITreeSnapshotExpression {
         return {
             elementName: this._elementName as TElementNameExpression,
+            nodeID: this._nodeID,
             argMap: this._getArgSnapshot(),
         };
     }
@@ -186,6 +188,7 @@ export class TreeNodeStatement extends TreeNodeInstruction implements ITreeNodeS
     public get snapshot(): ITreeSnapshotStatement {
         return {
             elementName: this._elementName as TElementNameStatement,
+            nodeID: this._nodeID,
             argMap: this._getArgSnapshot(),
         };
     }
@@ -211,6 +214,7 @@ export class TreeNodeBlock extends TreeNodeInstruction implements ITreeNodeBlock
 
         return {
             elementName: this._elementName as TElementNameBlock,
+            nodeID: this._nodeID,
             argMap: this._getArgSnapshot(),
             scope,
         };

--- a/src/syntax/tree/syntaxTree.spec.ts
+++ b/src/syntax/tree/syntaxTree.spec.ts
@@ -22,7 +22,7 @@ import { ElementValueBoolean } from '../elements/elementValue';
 import { ElementOperatorMathPlus } from '../elements/elementOperatorMath';
 import { ElementBoxBoolean } from '../elements/elementBox';
 import { TreeNodeData, TreeNodeStatement, TreeNodeBlock } from './node';
-import { ITreeSnapshot } from '@/@types/syntaxTree';
+import { ITreeSnapshotInput } from '@/@types/syntaxTree';
 
 // -------------------------------------------------------------------------------------------------
 
@@ -242,7 +242,7 @@ describe('Syntax Tree', () => {
 
     describe('tree generation from snapshot', () => {
         test('validate tree generation', () => {
-            const snapshotInput: ITreeSnapshot = {
+            const snapshotInput: ITreeSnapshotInput = {
                 process: [
                     {
                         elementName: 'process',
@@ -367,7 +367,43 @@ describe('Syntax Tree', () => {
             };
             generateFromSnapshot(snapshotInput);
             const snapshotOutput = generateSnapshot();
-            expect(snapshotOutput).toEqual(snapshotInput);
+
+            /* eslint-disable-next-line */
+            function __check(object1: object, object2: object): void {
+                if (object1 === null || object1 === undefined) {
+                    expect(object1).toBe(object2);
+                    return;
+                }
+
+                for (const key of Object.keys(object1)) {
+                    if (key === 'nodeID') {
+                        continue;
+                    }
+
+                    // @ts-ignore
+                    if (typeof object1[key] !== 'object') {
+                        // @ts-ignore
+                        expect(object1[key]).toEqual(object2[key]);
+                    } else {
+                        // @ts-ignore
+                        __check(object1[key], object2[key]);
+                    }
+                }
+            }
+
+            for (const i in snapshotInput.process) {
+                __check(snapshotInput.process[i], snapshotOutput.process[i]);
+            }
+
+            for (const i in snapshotInput.routine) {
+                __check(snapshotInput.routine[i], snapshotOutput.routine[i]);
+            }
+
+            for (const i in snapshotInput.crumbs) {
+                for (const j in snapshotInput.crumbs[i]) {
+                    __check(snapshotInput.crumbs[i][j], snapshotOutput.crumbs[i][j]);
+                }
+            }
         });
     });
 });

--- a/src/syntax/tree/syntaxTree.ts
+++ b/src/syntax/tree/syntaxTree.ts
@@ -21,10 +21,13 @@ import { TData } from '@/@types/data';
 import { ElementArgument } from '../elements/core/elementArgument';
 import {
     ITreeSnapshot,
-    ITreeSnapshotBlock,
-    ITreeSnapshotData,
-    ITreeSnapshotExpression,
+    ITreeSnapshotInput,
+    ITreeSnapshotDataInput,
+    ITreeSnapshotExpressionInput,
     ITreeSnapshotStatement,
+    ITreeSnapshotStatementInput,
+    ITreeSnapshotBlock,
+    ITreeSnapshotBlockInput,
 } from '@/@types/syntaxTree';
 
 // -- private variables ----------------------------------------------------------------------------
@@ -563,15 +566,15 @@ export function generateSnapshot(): ITreeSnapshot {
  * Generates the syntax tree from a snapshot.
  * @param snapshot - syntax tree snapshot
  */
-export function generateFromSnapshot(snapshot: ITreeSnapshot): void {
+export function generateFromSnapshot(snapshot: ITreeSnapshotInput): void {
     resetSyntaxTree();
 
     function __generateSnapshotList(
         snapshotList: (
-            | ITreeSnapshotData
-            | ITreeSnapshotExpression
-            | ITreeSnapshotStatement
-            | ITreeSnapshotBlock
+            | ITreeSnapshotDataInput
+            | ITreeSnapshotExpressionInput
+            | ITreeSnapshotStatementInput
+            | ITreeSnapshotBlockInput
         )[]
     ): string | null {
         if (snapshotList.length === 0) {
@@ -583,17 +586,21 @@ export function generateFromSnapshot(snapshot: ITreeSnapshot): void {
             let nodeID: string;
             switch (specification!.type) {
                 case 'Data':
-                    nodeID = __generateFromSnapshotData(snapshot as ITreeSnapshotData);
+                    nodeID = __generateFromSnapshotData(snapshot as ITreeSnapshotDataInput);
                     break;
                 case 'Expression':
-                    nodeID = __generateFromSnapshotExpression(snapshot as ITreeSnapshotExpression);
+                    nodeID = __generateFromSnapshotExpression(
+                        snapshot as ITreeSnapshotExpressionInput
+                    );
                     break;
                 case 'Statement':
-                    nodeID = __generateFromSnapshotStatement(snapshot as ITreeSnapshotStatement);
+                    nodeID = __generateFromSnapshotStatement(
+                        snapshot as ITreeSnapshotStatementInput
+                    );
                     break;
                 case 'Block':
                 default:
-                    nodeID = __generateFromSnapshotBlock(snapshot as ITreeSnapshotBlock);
+                    nodeID = __generateFromSnapshotBlock(snapshot as ITreeSnapshotBlockInput);
             }
             return nodeID;
         });
@@ -610,7 +617,7 @@ export function generateFromSnapshot(snapshot: ITreeSnapshot): void {
     function __generateFromSnapshotArg(
         nodeID: string,
         snapshot: {
-            [argName: string]: ITreeSnapshotData | ITreeSnapshotExpression | null;
+            [argName: string]: ITreeSnapshotDataInput | ITreeSnapshotExpressionInput | null;
         } | null
     ): void {
         if (snapshot === null) {
@@ -625,33 +632,35 @@ export function generateFromSnapshot(snapshot: ITreeSnapshot): void {
             let argNodeID: string;
             const specification = queryElementSpecification(snapshot.elementName)!;
             if (specification.type === 'Data') {
-                argNodeID = __generateFromSnapshotData(snapshot as ITreeSnapshotData);
+                argNodeID = __generateFromSnapshotData(snapshot as ITreeSnapshotDataInput);
             } else {
-                argNodeID = __generateFromSnapshotExpression(snapshot as ITreeSnapshotExpression);
+                argNodeID = __generateFromSnapshotExpression(
+                    snapshot as ITreeSnapshotExpressionInput
+                );
             }
 
             attachArgument(nodeID, argNodeID, argName);
         });
     }
 
-    function __generateFromSnapshotData(snapshot: ITreeSnapshotData): string {
+    function __generateFromSnapshotData(snapshot: ITreeSnapshotDataInput): string {
         const nodeID = addNode(snapshot.elementName);
         return nodeID;
     }
 
-    function __generateFromSnapshotExpression(snapshot: ITreeSnapshotExpression): string {
-        const nodeID = addNode(snapshot.elementName);
-        __generateFromSnapshotArg(nodeID, snapshot.argMap);
-        return nodeID;
-    }
-
-    function __generateFromSnapshotStatement(snapshot: ITreeSnapshotStatement): string {
+    function __generateFromSnapshotExpression(snapshot: ITreeSnapshotExpressionInput): string {
         const nodeID = addNode(snapshot.elementName);
         __generateFromSnapshotArg(nodeID, snapshot.argMap);
         return nodeID;
     }
 
-    function __generateFromSnapshotBlock(snapshot: ITreeSnapshotBlock): string {
+    function __generateFromSnapshotStatement(snapshot: ITreeSnapshotStatementInput): string {
+        const nodeID = addNode(snapshot.elementName);
+        __generateFromSnapshotArg(nodeID, snapshot.argMap);
+        return nodeID;
+    }
+
+    function __generateFromSnapshotBlock(snapshot: ITreeSnapshotBlockInput): string {
         const nodeID = addNode(snapshot.elementName);
         __generateFromSnapshotArg(nodeID, snapshot.argMap);
         const innerNodeID = __generateSnapshotList(snapshot.scope);


### PR DESCRIPTION
- Add `nodeID` field in each output snapshot
- Input snapshots don't require `nodeID` field