### PR TITLE
Specification: Added validation in functions

### DIFF
--- a/src/syntax/specification/specification.spec.ts
+++ b/src/syntax/specification/specification.spec.ts
@@ -160,13 +160,15 @@ describe('Syntax Element Specification', () => {
             }
         }
 
-        test('register element specification entry and verify', () => {
-            registerElementSpecificationEntry('dummy0', {
+        test('register new element specification entry and verify', () => {
+            const status = registerElementSpecificationEntry('dummy0', {
                 label: 'dummy0',
                 type: 'Block',
                 category: 'dummy',
                 prototype: DummyElementBlock,
             });
+            expect(status).toBe(true);
+
             const elementEntry = queryElementSpecification('dummy0' as TElementName)!;
             expect(elementEntry.label).toBe('dummy0');
             expect(elementEntry.type).toBe('Block');
@@ -181,8 +183,18 @@ describe('Syntax Element Specification', () => {
             ).toBe(true);
         });
 
-        test('register element specification entries and verify', () => {
-            registerElementSpecificationEntries({
+        test('register duplicate element specification entry and verify', () => {
+            const status = registerElementSpecificationEntry('dummy0', {
+                label: 'dummy0',
+                type: 'Block',
+                category: 'dummy',
+                prototype: DummyElementBlock,
+            });
+            expect(status).toBe(false);
+        });
+
+        test('register new element specification entries and verify', () => {
+            const status = registerElementSpecificationEntries({
                 dummy1: {
                     label: 'dummy1',
                     type: 'Data',
@@ -208,6 +220,7 @@ describe('Syntax Element Specification', () => {
                     prototype: DummyElementBlock,
                 },
             });
+            expect(status).toEqual([true, true, true, true]);
 
             const elementEntry1 = queryElementSpecification('dummy1' as TElementName)!;
             const elementEntry2 = queryElementSpecification('dummy2' as TElementName)!;
@@ -263,18 +276,78 @@ describe('Syntax Element Specification', () => {
             ).toBe(true);
         });
 
-        test('remove element specification entry and verify', () => {
-            removeElementSpecificationEntry('dummy0' as TElementName);
+        test('register duplicate element specification entries and verify', () => {
+            const status = registerElementSpecificationEntries({
+                dummy1: {
+                    label: 'dummy1',
+                    type: 'Data',
+                    category: 'dummy',
+                    prototype: DummyElementData,
+                },
+                dummy2: {
+                    label: 'dummy2',
+                    type: 'Expression',
+                    category: 'dummy',
+                    prototype: DummyElementExpression,
+                },
+                dummy3: {
+                    label: 'dummy3',
+                    type: 'Statement',
+                    category: 'dummy',
+                    prototype: DummyElementStatement,
+                },
+                dummy4: {
+                    label: 'dummy4',
+                    type: 'Block',
+                    category: 'dummy',
+                    prototype: DummyElementBlock,
+                },
+            });
+            expect(status).toEqual([false, false, false, false]);
+        });
+
+        test('remove valid element specification entry and verify', () => {
+            const removeStatus = removeElementSpecificationEntry('dummy0' as TElementName);
             const elementEntry = queryElementSpecification('dummy0' as TElementName)!;
+
+            expect(removeStatus).toBe(true);
             expect(elementEntry).toBe(null);
         });
 
-        test('remove element specification entries and verify', () => {
-            removeElementSpecificationEntries(['dummy1' as TElementName, 'dummy2' as TElementName]);
+        test('remove invalid element specification entry and verify', () => {
+            const removeStatus = removeElementSpecificationEntry('dummy0' as TElementName);
+            const elementEntry = queryElementSpecification('dummy0' as TElementName)!;
+
+            expect(removeStatus).toBe(false);
+            expect(elementEntry).toBe(null);
+        });
+
+        test('remove valid element specification entries and verify', () => {
+            const removeStatus = removeElementSpecificationEntries([
+                'dummy1' as TElementName,
+                'dummy2' as TElementName,
+                'dummy3' as TElementName,
+                'dummy4' as TElementName,
+            ]);
+            expect(removeStatus).toEqual([true, true, true, true]);
             expect(queryElementSpecification('dummy1' as TElementName)!).toBe(null);
             expect(queryElementSpecification('dummy2' as TElementName)!).toBe(null);
-            expect(queryElementSpecification('dummy3' as TElementName)!).not.toBe(null);
-            expect(queryElementSpecification('dummy4' as TElementName)!).not.toBe(null);
+            expect(queryElementSpecification('dummy3' as TElementName)!).toBe(null);
+            expect(queryElementSpecification('dummy4' as TElementName)!).toBe(null);
+        });
+
+        test('remove invalid element specification entries and verify', () => {
+            const removeStatus = removeElementSpecificationEntries([
+                'dummy1' as TElementName,
+                'dummy2' as TElementName,
+                'dummy3' as TElementName,
+                'dummy4' as TElementName,
+            ]);
+            expect(removeStatus).toEqual([false, false, false, false]);
+            expect(queryElementSpecification('dummy1' as TElementName)!).toBe(null);
+            expect(queryElementSpecification('dummy2' as TElementName)!).toBe(null);
+            expect(queryElementSpecification('dummy3' as TElementName)!).toBe(null);
+            expect(queryElementSpecification('dummy4' as TElementName)!).toBe(null);
         });
 
         test('reset element specification table and verify', () => {

--- a/src/syntax/specification/specification.ts
+++ b/src/syntax/specification/specification.ts
@@ -24,11 +24,14 @@ let _elementSpecification: {
  * Registers a syntax element specification from a given specification entry data.
  * @param name name of the syntax element
  * @param specification specification entry data
+ * @returns `false` if element name already exists, else `true`
  */
 export function registerElementSpecificationEntry(
     name: string,
     specification: IElementSpecification
-): void {
+): boolean {
+    if (name in _elementSpecification) return false;
+
     const { label, type, category, prototype } = specification;
 
     const specificationTableEntry: IElementSpecification = {
@@ -51,37 +54,49 @@ export function registerElementSpecificationEntry(
         | IElementSpecificationExpression
         | IElementSpecificationStatement
         | IElementSpecificationBlock;
+
+    return name in _elementSpecification;
 }
 
 /**
  * Registers a syntax element specification from a given specification entry table.
  * @param specification specification entry table object with key-value pairs of element name and
  *  corresponding specification entry data
+ * @returns a list of boolean , `false` if element name already exists else `true`
  */
 export function registerElementSpecificationEntries(specification: {
     [identifier: string]: IElementSpecification;
-}): void {
+}): boolean[] {
+    const registerStatus: boolean[] = [];
     Object.entries(specification).forEach(([identifier, specification]) =>
-        registerElementSpecificationEntry(identifier, specification)
+        registerStatus.push(registerElementSpecificationEntry(identifier, specification))
     );
+    return registerStatus;
 }
 
 /**
  * Removes specification for a syntax element.
  * @param name name of the syntax element
+ * @returns `true` if element is successfully removed, else `false` if element doesn't exist already
  */
-export function removeElementSpecificationEntry(name: string): void {
+export function removeElementSpecificationEntry(name: string): boolean {
     if (name in _elementSpecification) {
         delete _elementSpecification[name];
+        return true;
+    } else {
+        return false;
     }
 }
 
 /**
  * Removes specification for a list of syntax element.
  * @param names list of names of the syntax element
+ * @returns list of boolean, `true` if element is successfully removed, else `false`
  */
-export function removeElementSpecificationEntries(names: string[]): void {
-    names.forEach((name) => removeElementSpecificationEntry(name));
+export function removeElementSpecificationEntries(names: string[]): boolean[] {
+    const removeStatus: boolean[] = [];
+    names.forEach((name) => removeStatus.push(removeElementSpecificationEntry(name)));
+    return removeStatus;
 }
 
 /**


### PR DESCRIPTION
closes #112.

In first commit-

- [x] added validation in `registerElementSpecificationEntry` 
- [x] added validation in `registerElementSpecificationEntries`
- [x] added validation in `removeElementSpecificationEntry`
- [x] added validation in `removeElementSpecificationEntries`

In second commit-

- [x] renamed `register element specification entry and verify` test to `register new element specification entry and verify` 
- [x] added `register duplicate element specification entry and verify` test
- [x] renamed `register element specification entries and verify` test to `register new element specification entries and verify` 
- [x] added `register duplicate element specification entries and verify` test
- [x] renamed `remove element specification entry and verify` test to `remove valid element specification entry and verify` 
- [x] added `remove invalid element specification entries and verify` test
- [x] renamed `remove element specification entries and verify` test to `remove valid element specification entries and verify` 
- [x] added `remove invalid element specification entries and verify` test