### PR TITLE
Specification: Add snapshot function

### DIFF
--- a/src/@types/specification.d.ts
+++ b/src/@types/specification.d.ts
@@ -93,6 +93,7 @@ export type IElementSpecificationEntryBlock = IElementSpecificationInstruction &
     forbidNestInside?: string[];
 };
 
+/** Type for the specification object for an element. */
 export interface IElementSpecification {
     label: string;
     type: TElementType;
@@ -107,4 +108,9 @@ export interface IElementSpecification {
     forbiddenNestInside?: string[];
     allowNestInside?: string[] | boolean;
     forbidNestInside?: string[] | boolean;
+}
+
+/** Type for the snapshot of an element's specification. */
+export interface IElementSpecificationSnapshot extends Omit<IElementSpecification, 'prototype'> {
+    prototypeName: string;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export {
     getElementNames,
     getElementCategories,
     resetElementSpecificationTable,
+    getSpecificationSnapshot,
 } from './syntax/specification/specification';
 
 // -- syntax tree ----------------------------------------------------------------------------------

--- a/src/syntax/specification/specification.spec.ts
+++ b/src/syntax/specification/specification.spec.ts
@@ -5,6 +5,7 @@ import {
     removeElementSpecificationEntry,
     removeElementSpecificationEntries,
     resetElementSpecificationTable,
+    getSpecificationSnapshot,
 } from './specification';
 
 import elementSpecificationEntries from '../../library/specification';
@@ -339,6 +340,41 @@ describe('Syntax Element Specification', () => {
             resetElementSpecificationTable();
             expect(queryElementSpecification('dummy3')!).toBe(null);
             expect(queryElementSpecification('dummy4')!).toBe(null);
+        });
+
+        test('generate snapshot and verify', () => {
+            registerElementSpecificationEntries(elementSpecificationEntries);
+            expect(
+                Object.entries(getSpecificationSnapshot()).map(([key, value]) => [
+                    key,
+                    value.prototypeName,
+                ])
+            ).toEqual([
+                ['value-boolean', 'ElementValueBoolean'],
+                ['value-number', 'ElementValueNumber'],
+                ['value-string', 'ElementValueString'],
+                ['box-generic', 'ElementBoxGeneric'],
+                ['box-boolean', 'ElementBoxBoolean'],
+                ['box-number', 'ElementBoxNumber'],
+                ['box-string', 'ElementBoxString'],
+                ['boxidentifier-generic', 'ElementBoxIdentifierGeneric'],
+                ['boxidentifier-boolean', 'ElementBoxIdentifierBoolean'],
+                ['boxidentifier-number', 'ElementBoxIdentifierNumber'],
+                ['boxidentifier-string', 'ElementBoxIdentifierString'],
+                ['operator-math-plus', 'ElementOperatorMathPlus'],
+                ['operator-math-minus', 'ElementOperatorMathMinus'],
+                ['operator-math-times', 'ElementOperatorMathTimes'],
+                ['operator-math-divide', 'ElementOperatorMathDivide'],
+                ['operator-math-modulus', 'ElementOperatorMathModulus'],
+                ['repeat', 'ElementRepeat'],
+                ['if', 'ElementIf'],
+                ['process', 'ElementProcess'],
+                ['routine', 'ElementRoutine'],
+                ['print', 'ElementPrint'],
+            ]);
+
+            resetElementSpecificationTable();
+            expect(getSpecificationSnapshot()).toEqual({});
         });
     });
 });

--- a/src/syntax/specification/specification.ts
+++ b/src/syntax/specification/specification.ts
@@ -4,6 +4,7 @@ import {
     IElementSpecificationStatement,
     IElementSpecificationBlock,
     IElementSpecification,
+    IElementSpecificationSnapshot,
 } from '../../@types/specification';
 
 // -- private variables ----------------------------------------------------------------------------
@@ -15,6 +16,14 @@ let _elementSpecification: {
         | IElementSpecificationExpression
         | IElementSpecificationStatement
         | IElementSpecificationBlock;
+} = {};
+/**
+ * Stores the snapshot (similar to snapshot, except that prototype is replaced with prototype name —
+ * class name of the syntax element or the prototype) of the specifications for each element as a
+ * key-value pair of name: specification.
+ */
+let _elementSpecificationSnapshot: {
+    [identifier: string]: IElementSpecificationSnapshot;
 } = {};
 
 // -- public functions -----------------------------------------------------------------------------
@@ -41,6 +50,13 @@ export function registerElementSpecificationEntry(
         prototype: (name: string, label: string) => new prototype(name, label),
     };
 
+    const specificationSnapshotTableEntry: IElementSpecificationSnapshot = {
+        label,
+        type,
+        category,
+        prototypeName: prototype.name,
+    };
+
     Object.entries(specification).forEach(([key, value]) => {
         if (!['label', 'type', 'category', 'prototype'].includes(key)) {
             // @ts-ignore
@@ -53,6 +69,8 @@ export function registerElementSpecificationEntry(
         | IElementSpecificationExpression
         | IElementSpecificationStatement
         | IElementSpecificationBlock;
+
+    _elementSpecificationSnapshot[name] = specificationSnapshotTableEntry;
 
     return name in _elementSpecification;
 }
@@ -81,6 +99,7 @@ export function registerElementSpecificationEntries(specification: {
 export function removeElementSpecificationEntry(name: string): boolean {
     if (name in _elementSpecification) {
         delete _elementSpecification[name];
+        delete _elementSpecificationSnapshot[name];
         return true;
     } else {
         return false;
@@ -135,6 +154,18 @@ export function getElementCategories(): string[] {
  */
 export function resetElementSpecificationTable(): void {
     _elementSpecification = {};
+    _elementSpecificationSnapshot = {};
+}
+
+/**
+ * Returns the snapshot of the element specification table.
+ * @returns snapshot entry table object with key-value pairs of element name and corresponding
+ * element specification snapshot
+ */
+export function getSpecificationSnapshot(): {
+    [name: string]: IElementSpecificationSnapshot;
+} {
+    return _elementSpecificationSnapshot;
 }
 
 resetElementSpecificationTable();


### PR DESCRIPTION
closes #113. 

**Changes** - 
- added interface `IElementSpecificationSnapshot` in `specification.d.ts`
- added `generateSnapshot` function in `specification.ts`

Please review once whether the added `generateSnapshot` function meets your expectation, and if not please suggest the required changes

I will add the tests once the `generateSnapshot` function is reviewed and passed by the reviewer.

**Help Needed**-

- `@returns` comment for the function is exceeding 100 chars so I added a new line character in between, how to solve that without adding a new line.
- Should I change function name with `elementsSpecGenerateSnapshot` otherwise it will concide with [`generateSnapshot()` ](https://github.com/sugarlabs/musicblocks-v4-lib/blob/c4e49fcda7b5038dce83d62d3f354c0391398951/src/syntax/tree/syntaxTree.ts#L541) function name written in [`/src/syntax/tree/syntaxTree.ts`](https://github.com/sugarlabs/musicblocks-v4-lib/blob/c4e49fcda7b5038dce83d62d3f354c0391398951/src/syntax/tree/syntaxTree.ts)