### PR TITLE
Remove custom type reliance for element name

### DIFF
--- a/src/@types/elements.d.ts
+++ b/src/@types/elements.d.ts
@@ -1,12 +1,12 @@
 import { TData, TDataName } from './data';
-import { TElementName, TElementKind, TElementType } from './specification';
+import { TElementKind, TElementType } from './specification';
 
 // -------------------------------------------------------------------------------------------------
 
 /** Interface for the class that implements a syntax element. */
 export interface IElementSyntax {
     /** Name of the syntax element. */
-    name: TElementName;
+    name: string;
     /** Display name of the syntax element. */
     label: string;
     /** Kind (`Argument`, `Instruction`) of the syntax element. */

--- a/src/@types/specification.d.ts
+++ b/src/@types/specification.d.ts
@@ -14,54 +14,12 @@ export type TElementKind = 'Argument' | 'Instruction';
 /** Type (`Data`, `Expression`, `Statement`, `Block`) of the syntax element. */
 export type TElementType = 'Data' | 'Expression' | 'Statement' | 'Block';
 
-/** Names of factory list of data elements. */
-export type TElementNameData =
-    // value elements
-    | 'value-boolean'
-    | 'value-number'
-    | 'value-string'
-    // box identifier elements
-    | 'boxidentifier-generic'
-    | 'boxidentifier-boolean'
-    | 'boxidentifier-number'
-    | 'boxidentifier-string';
-
-/** Names of factory list of expression elements. */
-export type TElementNameExpression =
-    // math operator elements
-    | 'operator-math-plus'
-    | 'operator-math-minus'
-    | 'operator-math-times'
-    | 'operator-math-divide'
-    | 'operator-math-modulus';
-
-/** Names of factory list of statement elements. */
-export type TElementNameStatement =
-    // box elements
-    | 'box-generic'
-    | 'box-boolean'
-    | 'box-number'
-    | 'box-string'
-    // print element
-    | 'print';
-
-/** Names of factory list of block elements. */
-export type TElementNameBlock = 'process' | 'routine' | 'repeat' | 'if';
-
-/** Names of factory list of syntax elements. */
-export type TElementName =
-    | 'dummy'
-    | TElementNameData
-    | TElementNameExpression
-    | TElementNameStatement
-    | TElementNameBlock;
-
 /** Type for the specification object for data elements. */
 export interface IElementSpecificationData {
     label: string;
     type: 'Data';
     category: string;
-    prototype: (name: TElementNameData, label: string) => IElementData<TData>;
+    prototype: (name: string, label: string) => IElementData<TData>;
 }
 
 /** Type for the specification entry object for data elements. */
@@ -77,7 +35,7 @@ export interface IElementSpecificationExpression {
     label: string;
     type: 'Expression';
     category: string;
-    prototype: (name: TElementNameExpression, label: string) => IElementExpression<TData>;
+    prototype: (name: string, label: string) => IElementExpression<TData>;
 }
 
 /** Type for the specification object for expression elements. */
@@ -90,13 +48,13 @@ export interface IElementSpecificationEntryExpression extends IElementSpecificat
 
 /** Type for the specification object for instruction elements. */
 interface IElementSpecificationInstruction {
-    allowAbove?: TElementName[] | boolean;
-    allowBelow?: TElementName[] | boolean;
-    forbidAbove?: TElementName[];
-    forbidBelow?: TElementName[];
+    allowAbove?: string[] | boolean;
+    allowBelow?: string[] | boolean;
+    forbidAbove?: string[];
+    forbidBelow?: string[];
     allowedNestLevel?: number[] | 'any';
-    allowedNestInside?: TElementNameBlock[] | boolean;
-    forbiddenNestInside?: TElementNameBlock[];
+    allowedNestInside?: string[] | boolean;
+    forbiddenNestInside?: string[];
 }
 
 /** Type for the specification object for statement elements. */
@@ -104,7 +62,7 @@ export type IElementSpecificationStatement = IElementSpecificationInstruction & 
     label: string;
     type: 'Statement';
     category: string;
-    prototype: (name: TElementNameStatement, label: string) => IElementStatement;
+    prototype: (name: string, label: string) => IElementStatement;
 };
 
 /** Type for the specification object for statement elements. */
@@ -120,9 +78,9 @@ export type IElementSpecificationBlock = IElementSpecificationInstruction & {
     label: string;
     type: 'Block';
     category: string;
-    prototype: (name: TElementNameBlock, label: string) => IElementBlock;
-    allowNestInside?: (TElementNameStatement | TElementNameBlock)[] | boolean;
-    forbidNestInside?: (TElementNameStatement | TElementNameBlock)[];
+    prototype: (name: string, label: string) => IElementBlock;
+    allowNestInside?: string[] | boolean;
+    forbidNestInside?: string[];
 };
 
 /** Type for the specification entry object for block elements. */
@@ -131,22 +89,22 @@ export type IElementSpecificationEntryBlock = IElementSpecificationInstruction &
     type: 'Block';
     category: string;
     prototype: typeof IElementBlock;
-    allowNestInside?: (TElementNameStatement | TElementNameBlock)[] | boolean;
-    forbidNestInside?: (TElementNameStatement | TElementNameBlock)[];
+    allowNestInside?: string[] | boolean;
+    forbidNestInside?: string[];
 };
 
 export interface IElementSpecification {
     label: string;
     type: TElementType;
     category: string;
-    prototype: new (name: TElementName, label: string) => IElementSyntax;
-    allowAbove?: TElementName[] | boolean;
-    allowBelow?: TElementName[] | boolean;
-    forbidAbove?: TElementName[];
-    forbidBelow?: TElementName[];
+    prototype: new (name: string, label: string) => IElementSyntax;
+    allowAbove?: string[] | boolean;
+    allowBelow?: string[] | boolean;
+    forbidAbove?: string[];
+    forbidBelow?: string[];
     allowedNestLevel?: number[] | 'any';
-    allowedNestInside?: TElementNameBlock[] | boolean;
-    forbiddenNestInside?: TElementNameBlock[];
-    allowNestInside?: (TElementNameStatement | TElementNameBlock)[] | boolean;
-    forbidNestInside?: (TElementNameStatement | TElementNameBlock)[] | boolean;
+    allowedNestInside?: string[] | boolean;
+    forbiddenNestInside?: string[];
+    allowNestInside?: string[] | boolean;
+    forbidNestInside?: string[] | boolean;
 }

--- a/src/@types/syntaxTree.d.ts
+++ b/src/@types/syntaxTree.d.ts
@@ -1,11 +1,3 @@
-import {
-    TElementNameData,
-    TElementNameExpression,
-    TElementNameStatement,
-    TElementNameBlock,
-    TElementName,
-} from './specification';
-
 // -- snapshots ------------------------------------------------------------------------------------
 
 /** Type definition for the snapshot input of a data element. */
@@ -105,7 +97,7 @@ export interface ITreeSnapshot {
 /** Type definition for the class that implements a generic syntax tree node. */
 interface ITreeNode {
     /** Name of the syntax element. */
-    elementName: TElementName;
+    elementName: string;
     /** Node ID of the syntax tree node instance. */
     nodeID: string;
     /** Warehouse ID of the syntax element instance. */
@@ -121,7 +113,7 @@ export interface ITreeNodeArgument extends ITreeNode {
 /** Type definition for the class that implements a syntax tree data node. */
 export interface ITreeNodeData extends ITreeNodeArgument {
     /** Name of the data element. */
-    elementName: TElementNameData;
+    elementName: string;
     /** Returns a snapshot of the syntax tree data node. */
     snapshot: ITreeSnapshotData;
 }
@@ -129,7 +121,7 @@ export interface ITreeNodeData extends ITreeNodeArgument {
 /** Type definition for the class that implements a syntax tree expression node. */
 export interface ITreeNodeExpression extends ITreeNodeArgument {
     /** Name of the expression element. */
-    elementName: TElementNameExpression;
+    elementName: string;
     /** Returns a snapshot of the syntax tree expression node. */
     snapshot: ITreeSnapshotExpression;
     /** Object with key-value pairs of argument names and corresponding argument nodes. */
@@ -175,7 +167,7 @@ export interface ITreeNodeInstruction extends ITreeNode {
 /** Type definition for the class that implements a syntax tree statement node. */
 export interface ITreeNodeStatement extends ITreeNodeInstruction {
     /** Name of the statement element. */
-    elementName: TElementNameStatement;
+    elementName: string;
     /** Returns a snapshot of the syntax tree statement node. */
     snapshot: ITreeSnapshotStatement;
 }
@@ -183,7 +175,7 @@ export interface ITreeNodeStatement extends ITreeNodeInstruction {
 /** Type definition for the class that implements a syntax tree block node. */
 export interface ITreeNodeBlock extends ITreeNodeInstruction {
     /** Name of the block element. */
-    elementName: TElementNameBlock;
+    elementName: string;
     /** Returns a snapshot of the syntax tree block node. */
     snapshot: ITreeSnapshotBlock;
     /** Syntax tree node reference of the first nested instruction element. */

--- a/src/execution/parser.ts
+++ b/src/execution/parser.ts
@@ -15,7 +15,6 @@ import { getInstance } from '../syntax/warehouse/warehouse';
 import { TData } from '../@types/data';
 import { ElementData, ElementExpression } from '../syntax/elements/elementArgument';
 import { ElementBlock, ElementStatement } from '../syntax/elements/elementInstruction';
-import { TElementName } from '../@types/specification';
 
 // -- private variables ----------------------------------------------------------------------------
 
@@ -528,10 +527,10 @@ export function getNextElement(): IParsedElement | null {
  */
 export function stackTrace():
     | {
-          elementName: TElementName | null;
+          elementName: string | null;
           nodeID: string | null;
           pages:
-              | { elementName: TElementName | null; nodeID: string | null; marker: string | null }[]
+              | { elementName: string | null; nodeID: string | null; marker: string | null }[]
               | null;
       }[]
     | null {

--- a/src/library/elements/elementBox.ts
+++ b/src/library/elements/elementBox.ts
@@ -1,5 +1,4 @@
 import { TData, TDataName } from '../../@types/data';
-import { TElementName } from '../../@types/specification';
 
 import { ElementStatement } from '../../syntax/elements/elementInstruction';
 import { declareVariable } from '../../execution/interpreter';
@@ -15,7 +14,7 @@ import { declareVariable } from '../../execution/interpreter';
  * Box elements add (declare) variables to the symbol table.
  */
 abstract class ElementBox extends ElementStatement {
-    constructor(name: TElementName, label: string, types: TDataName[]) {
+    constructor(name: string, label: string, types: TDataName[]) {
         super(name, label, {
             name: ['string'],
             value: types,
@@ -45,7 +44,7 @@ abstract class ElementBox extends ElementStatement {
  * Defines a box element that declares a variable of any data type.
  */
 export class ElementBoxGeneric extends ElementBox {
-    constructor(name: TElementName, label: string) {
+    constructor(name: string, label: string) {
         super(name, label, ['boolean', 'number', 'string']);
     }
 
@@ -60,7 +59,7 @@ export class ElementBoxGeneric extends ElementBox {
  * Defines a box element that declares a variable of boolean type.
  */
 export class ElementBoxBoolean extends ElementBox {
-    constructor(name: TElementName, label: string) {
+    constructor(name: string, label: string) {
         super(name, label, ['boolean']);
     }
 
@@ -75,7 +74,7 @@ export class ElementBoxBoolean extends ElementBox {
  * Defines a box element that declares a variable of number type.
  */
 export class ElementBoxNumber extends ElementBox {
-    constructor(name: TElementName, label: string) {
+    constructor(name: string, label: string) {
         super(name, label, ['number']);
     }
 
@@ -90,7 +89,7 @@ export class ElementBoxNumber extends ElementBox {
  * Defines a box element that declares a variable of string type.
  */
 export class ElementBoxString extends ElementBox {
-    constructor(name: TElementName, label: string) {
+    constructor(name: string, label: string) {
         super(name, label, ['string']);
     }
 

--- a/src/library/elements/elementBoxIdentifier.ts
+++ b/src/library/elements/elementBoxIdentifier.ts
@@ -1,5 +1,4 @@
 import { TData, TDataName } from '../../@types/data';
-import { TElementName } from '../../@types/specification';
 
 import { ElementData } from '../../syntax/elements/elementArgument';
 import { queryVariable } from '../../execution/interpreter';
@@ -15,16 +14,16 @@ import { queryVariable } from '../../execution/interpreter';
  * @throws `Error` (ItemNotFoundError)
  */
 abstract class ElementBoxIdentifier<T> extends ElementData<T> {
-    constructor(name: TElementName, label: string, returnType: ['boolean'], initialValue: boolean);
-    constructor(name: TElementName, label: string, returnType: ['number'], initialValue: number);
-    constructor(name: TElementName, label: string, returnType: ['string'], initialValue: string);
+    constructor(name: string, label: string, returnType: ['boolean'], initialValue: boolean);
+    constructor(name: string, label: string, returnType: ['number'], initialValue: number);
+    constructor(name: string, label: string, returnType: ['string'], initialValue: string);
     constructor(
-        name: TElementName,
+        name: string,
         label: string,
         returnType: ['boolean', 'number', 'string'],
         initialValue: TData
     );
-    constructor(name: TElementName, label: string, returnType: TDataName[], initialValue: T) {
+    constructor(name: string, label: string, returnType: TDataName[], initialValue: T) {
         super(name, label, {}, returnType, initialValue);
     }
 
@@ -59,7 +58,7 @@ abstract class ElementBoxIdentifier<T> extends ElementData<T> {
  * @throws `Error` (ItemNotFoundError)
  */
 export class ElementBoxIdentifierGeneric extends ElementBoxIdentifier<TData> {
-    constructor(name: TElementName, label: string) {
+    constructor(name: string, label: string) {
         super(name, label, ['boolean', 'number', 'string'], '');
     }
 }
@@ -70,7 +69,7 @@ export class ElementBoxIdentifierGeneric extends ElementBoxIdentifier<TData> {
  * @throws `Error` (ItemNotFoundError)
  */
 export class ElementBoxIdentifierBoolean extends ElementBoxIdentifier<boolean> {
-    constructor(name: TElementName, label: string) {
+    constructor(name: string, label: string) {
         super(name, label, ['boolean'], true);
     }
 }
@@ -81,7 +80,7 @@ export class ElementBoxIdentifierBoolean extends ElementBoxIdentifier<boolean> {
  * @throws `Error` (ItemNotFoundError)
  */
 export class ElementBoxIdentifierNumber extends ElementBoxIdentifier<number> {
-    constructor(name: TElementName, label: string) {
+    constructor(name: string, label: string) {
         super(name, label, ['number'], 0);
     }
 }
@@ -92,7 +91,7 @@ export class ElementBoxIdentifierNumber extends ElementBoxIdentifier<number> {
  * @throws `Error` (ItemNotFoundError)
  */
 export class ElementBoxIdentifierString extends ElementBoxIdentifier<string> {
-    constructor(name: TElementName, label: string) {
+    constructor(name: string, label: string) {
         super(name, label, ['string'], '');
     }
 }

--- a/src/library/elements/elementConditional.ts
+++ b/src/library/elements/elementConditional.ts
@@ -1,4 +1,3 @@
-import { TElementNameBlock } from '../../@types/specification';
 import { ElementBlock } from '../../syntax/elements/elementInstruction';
 
 import { overrideProgramCounter } from '../../execution/interpreter';
@@ -12,7 +11,7 @@ import { overrideProgramCounter } from '../../execution/interpreter';
  * Allows entry to scope only if condition is satisfied.
  */
 export class ElementIf extends ElementBlock {
-    constructor(name: TElementNameBlock, label: string) {
+    constructor(name: string, label: string) {
         super(name, label, { condition: ['boolean'] });
     }
 

--- a/src/library/elements/elementLoop.ts
+++ b/src/library/elements/elementLoop.ts
@@ -1,4 +1,3 @@
-import { TElementNameBlock } from '../../@types/specification';
 import { ElementBlock } from '../../syntax/elements/elementInstruction';
 
 import { overrideProgramCounter } from '../../execution/interpreter';
@@ -12,7 +11,7 @@ import { overrideProgramCounter } from '../../execution/interpreter';
  * Repeats the scope as many times as the parameter provided.
  */
 export class ElementRepeat extends ElementBlock {
-    constructor(name: TElementNameBlock, label: string) {
+    constructor(name: string, label: string) {
         super(name, label, { times: ['number'] });
     }
 

--- a/src/library/elements/elementOperatorMath.ts
+++ b/src/library/elements/elementOperatorMath.ts
@@ -1,5 +1,4 @@
 import { TData, TDataName } from '../../@types/data';
-import { TElementName } from '../../@types/specification';
 import { ElementExpression } from '../../syntax/elements/elementArgument';
 
 // -------------------------------------------------------------------------------------------------
@@ -20,7 +19,7 @@ abstract class ElementOperatorMath<T> extends ElementExpression<T> {
     private _operator: TOperator;
 
     constructor(
-        name: TElementName,
+        name: string,
         label: string,
         returnType: TDataName[],
         operator: TOperator,
@@ -66,7 +65,7 @@ abstract class ElementOperatorMath<T> extends ElementExpression<T> {
  * Performs addition on numbers and concatenation on strings.
  */
 export class ElementOperatorMathPlus extends ElementOperatorMath<number | string> {
-    constructor(name: TElementName, label: string) {
+    constructor(name: string, label: string) {
         super(name, label, ['number', 'string'], '+', 0);
     }
 }
@@ -79,7 +78,7 @@ export class ElementOperatorMathPlus extends ElementOperatorMath<number | string
  * Performs subtraction on numbers.
  */
 export class ElementOperatorMathMinus extends ElementOperatorMath<number> {
-    constructor(name: TElementName, label: string) {
+    constructor(name: string, label: string) {
         super(name, label, ['number'], '-', 0);
     }
 }
@@ -92,7 +91,7 @@ export class ElementOperatorMathMinus extends ElementOperatorMath<number> {
  * Performs multiplication on numbers.
  */
 export class ElementOperatorMathTimes extends ElementOperatorMath<number> {
-    constructor(name: TElementName, label: string) {
+    constructor(name: string, label: string) {
         super(name, label, ['number'], '*', 0);
     }
 }
@@ -105,7 +104,7 @@ export class ElementOperatorMathTimes extends ElementOperatorMath<number> {
  * Performs division on numbers.
  */
 export class ElementOperatorMathDivide extends ElementOperatorMath<number> {
-    constructor(name: TElementName, label: string) {
+    constructor(name: string, label: string) {
         super(name, label, ['number'], '/', 0);
     }
 }
@@ -118,7 +117,7 @@ export class ElementOperatorMathDivide extends ElementOperatorMath<number> {
  * Performs modulus operation on numbers.
  */
 export class ElementOperatorMathModulus extends ElementOperatorMath<number> {
-    constructor(name: TElementName, label: string) {
+    constructor(name: string, label: string) {
         super(name, label, ['number'], '%', 0);
     }
 }

--- a/src/library/elements/elementPrint.ts
+++ b/src/library/elements/elementPrint.ts
@@ -1,11 +1,10 @@
 import { TData } from '../../@types/data';
-import { TElementNameStatement } from '../../@types/specification';
 import { ElementStatement } from '../../syntax/elements/elementInstruction';
 
 // -------------------------------------------------------------------------------------------------
 
 export class ElementPrint extends ElementStatement {
-    constructor(name: TElementNameStatement, label: string) {
+    constructor(name: string, label: string) {
         super(name, label, { value: ['boolean', 'number', 'string'] });
     }
 

--- a/src/library/elements/elementProgram.ts
+++ b/src/library/elements/elementProgram.ts
@@ -1,8 +1,7 @@
-import { TElementNameBlock } from '../../@types/specification';
 import { ElementBlock } from '../../syntax/elements/elementInstruction';
 
 export class ElementProcess extends ElementBlock {
-    constructor(name: TElementNameBlock, label: string) {
+    constructor(name: string, label: string) {
         super(name, label, {});
     }
 
@@ -24,7 +23,7 @@ export class ElementProcess extends ElementBlock {
 }
 
 export class ElementRoutine extends ElementBlock {
-    constructor(name: TElementNameBlock, label: string) {
+    constructor(name: string, label: string) {
         super(name, label, { name: ['string'] });
     }
 

--- a/src/library/elements/elementValue.ts
+++ b/src/library/elements/elementValue.ts
@@ -1,5 +1,4 @@
 import { TDataName } from '../../@types/data';
-import { TElementName } from '../../@types/specification';
 
 import { ElementData } from '../../syntax/elements/elementArgument';
 
@@ -14,10 +13,10 @@ import { ElementData } from '../../syntax/elements/elementArgument';
  * Value elements return a stored value.
  */
 abstract class ElementValue<T> extends ElementData<T> {
-    constructor(name: TElementName, label: string, returnType: ['number'], initialValue: number);
-    constructor(name: TElementName, label: string, returnType: ['string'], initialValue: string);
-    constructor(name: TElementName, label: string, returnType: ['boolean'], initialValue: boolean);
-    constructor(name: TElementName, label: string, returnType: [TDataName], initialValue: T) {
+    constructor(name: string, label: string, returnType: ['number'], initialValue: number);
+    constructor(name: string, label: string, returnType: ['string'], initialValue: string);
+    constructor(name: string, label: string, returnType: ['boolean'], initialValue: boolean);
+    constructor(name: string, label: string, returnType: [TDataName], initialValue: T) {
         super(name, '', {}, returnType, initialValue);
         this.updateLabel(label);
     }
@@ -52,7 +51,7 @@ abstract class ElementValue<T> extends ElementData<T> {
  * @throws `Error` (TypeMismatchError)
  */
 export class ElementValueBoolean extends ElementValue<boolean> {
-    constructor(name: TElementName, label: string) {
+    constructor(name: string, label: string) {
         super(name, label, ['boolean'], true);
     }
 }
@@ -63,7 +62,7 @@ export class ElementValueBoolean extends ElementValue<boolean> {
  * @throws `Error` (TypeMismatchError)
  */
 export class ElementValueNumber extends ElementValue<number> {
-    constructor(name: TElementName, label: string) {
+    constructor(name: string, label: string) {
         super(name, label, ['number'], 0);
     }
 }
@@ -74,7 +73,7 @@ export class ElementValueNumber extends ElementValue<number> {
  * @throws `Error` (TypeMismatchError)
  */
 export class ElementValueString extends ElementValue<string> {
-    constructor(name: TElementName, label: string) {
+    constructor(name: string, label: string) {
         super(name, label, ['string'], '');
     }
 }

--- a/src/syntax/elements/elementArgument.ts
+++ b/src/syntax/elements/elementArgument.ts
@@ -1,5 +1,4 @@
 import { TData, TDataName } from '../../@types/data';
-import { TElementName } from '../../@types/specification';
 import { IElementArgument, IElementExpression, IElementData } from '../../@types/elements';
 
 import { ElementSyntax } from './elementSyntax';
@@ -32,7 +31,7 @@ export abstract class ElementArgument<T> extends ElementSyntax implements IEleme
      * @param initialValue initial return value of the argument
      */
     constructor(
-        name: TElementName,
+        name: string,
         label: string,
         type: 'Data' | 'Expression',
         argMap: { [key: string]: TDataName[] },
@@ -72,7 +71,7 @@ export abstract class ElementData<T> extends ElementArgument<T> implements IElem
      * @param initialValue - initial return value of the argument
      */
     constructor(
-        name: TElementName,
+        name: string,
         label: string,
         argMap: { [key: string]: TDataName[] },
         returnType: TDataName[],
@@ -106,7 +105,7 @@ export abstract class ElementExpression<T>
      * @param initialValue initial return value of the argument
      */
     constructor(
-        name: TElementName,
+        name: string,
         label: string,
         argMap: { [key: string]: TDataName[] },
         returnType: TDataName[],

--- a/src/syntax/elements/elementInstruction.ts
+++ b/src/syntax/elements/elementInstruction.ts
@@ -1,5 +1,4 @@
 import { TData, TDataName } from '../../@types/data';
-import { TElementName } from '../../@types/specification';
 import { IElementBlock, IElementInstruction, IElementStatement } from '../../@types/elements';
 
 import { ElementSyntax } from './elementSyntax';
@@ -24,7 +23,7 @@ export abstract class ElementInstruction extends ElementSyntax implements IEleme
      *  `argName: type[]` pair
      */
     constructor(
-        name: TElementName,
+        name: string,
         label: string,
         type: 'Statement' | 'Block',
         argMap: { [key: string]: TDataName[] }
@@ -50,7 +49,7 @@ export abstract class ElementStatement extends ElementInstruction implements IEl
      * @param argMap an object describing the type specification of each argument as a
      *  `argName: type[]` pair
      */
-    constructor(name: TElementName, label: string, argMap: { [key: string]: TDataName[] }) {
+    constructor(name: string, label: string, argMap: { [key: string]: TDataName[] }) {
         super(name, label, 'Statement', argMap);
     }
 }
@@ -72,7 +71,7 @@ export abstract class ElementBlock extends ElementInstruction implements IElemen
      * @param argMap an object describing the type specification of each argument as a
      *  `argName: type[]` pair
      */
-    constructor(name: TElementName, label: string, argMap: { [key: string]: TDataName[] }) {
+    constructor(name: string, label: string, argMap: { [key: string]: TDataName[] }) {
         super(name, label, 'Block', argMap);
     }
 

--- a/src/syntax/elements/elementSyntax.spec.ts
+++ b/src/syntax/elements/elementSyntax.spec.ts
@@ -1,12 +1,11 @@
 import { TDataName } from '../../@types/data';
-import { TElementName } from '../../@types/specification';
 import { ElementSyntax } from './elementSyntax';
 
 // -------------------------------------------------------------------------------------------------
 
 class DummyElementSyntax extends ElementSyntax {
     constructor(
-        name: TElementName,
+        name: string,
         label: string,
         kind: 'Argument' | 'Instruction',
         type: 'Data' | 'Expression' | 'Statement' | 'Block',
@@ -21,13 +20,7 @@ describe('class ElementSyntax', () => {
         test('instantiate class that extends ElementSyntax with 0 arguments and validate API', () => {
             let dummyElementSyntax: DummyElementSyntax;
 
-            dummyElementSyntax = new DummyElementSyntax(
-                'dummy' as TElementName,
-                'dummy',
-                'Argument',
-                'Data',
-                {}
-            );
+            dummyElementSyntax = new DummyElementSyntax('dummy', 'dummy', 'Argument', 'Data', {});
             expect(dummyElementSyntax.name).toBe('dummy');
             expect(dummyElementSyntax.label).toBe('dummy');
             expect(dummyElementSyntax.kind).toBe('Argument');
@@ -36,7 +29,7 @@ describe('class ElementSyntax', () => {
             expect(dummyElementSyntax.argLabels).toEqual([]);
 
             dummyElementSyntax = new DummyElementSyntax(
-                'dummy' as TElementName,
+                'dummy',
                 'dummy',
                 'Argument',
                 'Expression',
@@ -50,7 +43,7 @@ describe('class ElementSyntax', () => {
             expect(dummyElementSyntax.argLabels).toEqual([]);
 
             dummyElementSyntax = new DummyElementSyntax(
-                'dummy' as TElementName,
+                'dummy',
                 'dummy',
                 'Instruction',
                 'Statement',
@@ -64,7 +57,7 @@ describe('class ElementSyntax', () => {
             expect(dummyElementSyntax.argLabels).toEqual([]);
 
             dummyElementSyntax = new DummyElementSyntax(
-                'dummy' as TElementName,
+                'dummy',
                 'dummy',
                 'Instruction',
                 'Block',
@@ -80,7 +73,7 @@ describe('class ElementSyntax', () => {
 
         test('instantiate class that extends ElementSyntax with 3 arguments and validate API', () => {
             const dummyElementSyntax = new DummyElementSyntax(
-                'dummy' as TElementName,
+                'dummy',
                 'dummy',
                 'Instruction',
                 'Block',
@@ -103,13 +96,7 @@ describe('class ElementSyntax', () => {
     });
 
     test('update label and verify', () => {
-        const dummyElementSyntax = new DummyElementSyntax(
-            'dummy' as TElementName,
-            'dummy',
-            'Argument',
-            'Data',
-            {}
-        );
+        const dummyElementSyntax = new DummyElementSyntax('dummy', 'dummy', 'Argument', 'Data', {});
         expect(dummyElementSyntax.label).toBe('dummy');
         dummyElementSyntax.updateLabel('dummyElement');
         expect(dummyElementSyntax.label).toBe('dummyElement');

--- a/src/syntax/elements/elementSyntax.ts
+++ b/src/syntax/elements/elementSyntax.ts
@@ -1,5 +1,4 @@
 import { TDataName } from '../../@types/data';
-import { TElementName } from '../../@types/specification';
 import { IElementSyntax } from '../../@types/elements';
 
 // -------------------------------------------------------------------------------------------------
@@ -15,7 +14,7 @@ import { IElementSyntax } from '../../@types/elements';
  */
 export abstract class ElementSyntax implements IElementSyntax {
     /** Stores the name of the syntax element. */
-    private _name: TElementName;
+    private _name: string;
     /** Stores the display name of the syntax element. */
     private _label: string;
     /** Stores the kind of the syntax element. */
@@ -39,7 +38,7 @@ export abstract class ElementSyntax implements IElementSyntax {
      *  `argName: type[]` pair
      */
     constructor(
-        name: TElementName,
+        name: string,
         label: string,
         kind: 'Argument' | 'Instruction',
         type: 'Data' | 'Expression' | 'Statement' | 'Block',
@@ -54,7 +53,7 @@ export abstract class ElementSyntax implements IElementSyntax {
         this._argCount = this.argLabels.length;
     }
 
-    public get name(): TElementName {
+    public get name(): string {
         return this._name;
     }
 

--- a/src/syntax/specification/specification.spec.ts
+++ b/src/syntax/specification/specification.spec.ts
@@ -1,11 +1,4 @@
 import {
-    TElementNameData,
-    TElementNameExpression,
-    TElementNameStatement,
-    TElementNameBlock,
-    TElementName,
-} from '../../@types/specification';
-import {
     registerElementSpecificationEntry,
     registerElementSpecificationEntries,
     queryElementSpecification,
@@ -40,7 +33,7 @@ describe('Syntax Element Specification', () => {
 
             test('instantiate prototype fetch from entry query and verify instance', () => {
                 const prototype = dataElementEntry.prototype as (
-                    name: TElementNameData,
+                    name: string,
                     label: string
                 ) => ElementDataCover;
                 const elementInstance = prototype('value-boolean', dataElementEntry.label);
@@ -61,7 +54,7 @@ describe('Syntax Element Specification', () => {
 
             test('instantiate prototype fetch from entry query and verify instance', () => {
                 const prototype = dataElementEntry.prototype as (
-                    name: TElementNameExpression,
+                    name: string,
                     label: string
                 ) => ElementExpressionCover;
                 const elementInstance = prototype('operator-math-plus', dataElementEntry.label);
@@ -82,7 +75,7 @@ describe('Syntax Element Specification', () => {
 
             test('instantiate prototype fetch from entry query and verify instance', () => {
                 const prototype = dataElementEntry.prototype as (
-                    name: TElementNameStatement,
+                    name: string,
                     label: string
                 ) => ElementStatement;
                 const elementInstance = prototype('box-generic', dataElementEntry.label);
@@ -103,7 +96,7 @@ describe('Syntax Element Specification', () => {
 
             test('instantiate prototype fetch from entry query and verify instance', () => {
                 const prototype = dataElementEntry.prototype as (
-                    name: TElementNameBlock,
+                    name: string,
                     label: string
                 ) => ElementBlock;
                 const elementInstance = prototype('process', dataElementEntry.label);
@@ -116,7 +109,7 @@ describe('Syntax Element Specification', () => {
 
     describe('functions', () => {
         class DummyElementData extends ElementData<TData> {
-            constructor(name: TElementName, label: string) {
+            constructor(name: string, label: string) {
                 super(name, label, {}, ['number'], 0);
             }
             public evaluate(): void {
@@ -125,7 +118,7 @@ describe('Syntax Element Specification', () => {
         }
 
         class DummyElementExpression extends ElementExpression<TData> {
-            constructor(name: TElementName, label: string) {
+            constructor(name: string, label: string) {
                 super(name, label, {}, ['number'], 0);
             }
             public evaluate(): void {
@@ -134,7 +127,7 @@ describe('Syntax Element Specification', () => {
         }
 
         class DummyElementStatement extends ElementStatement {
-            constructor(name: TElementName, label: string) {
+            constructor(name: string, label: string) {
                 super(name, label, {});
             }
             public onVisit(): void {
@@ -143,7 +136,7 @@ describe('Syntax Element Specification', () => {
         }
 
         class DummyElementBlock extends ElementBlock {
-            constructor(name: TElementName, label: string) {
+            constructor(name: string, label: string) {
                 super(name, label, {});
             }
             public onVisit(): void {
@@ -169,17 +162,15 @@ describe('Syntax Element Specification', () => {
             });
             expect(status).toBe(true);
 
-            const elementEntry = queryElementSpecification('dummy0' as TElementName)!;
+            const elementEntry = queryElementSpecification('dummy0')!;
             expect(elementEntry.label).toBe('dummy0');
             expect(elementEntry.type).toBe('Block');
             expect(elementEntry.category).toBe('dummy');
             expect(
-                (
-                    elementEntry.prototype as (
-                        name: TElementNameBlock,
-                        label: string
-                    ) => ElementBlock
-                )('dummy0' as TElementNameBlock, 'dummy0') instanceof DummyElementBlock
+                (elementEntry.prototype as (name: string, label: string) => ElementBlock)(
+                    'dummy0',
+                    'dummy0'
+                ) instanceof DummyElementBlock
             ).toBe(true);
         });
 
@@ -222,21 +213,19 @@ describe('Syntax Element Specification', () => {
             });
             expect(status).toEqual([true, true, true, true]);
 
-            const elementEntry1 = queryElementSpecification('dummy1' as TElementName)!;
-            const elementEntry2 = queryElementSpecification('dummy2' as TElementName)!;
-            const elementEntry3 = queryElementSpecification('dummy3' as TElementName)!;
-            const elementEntry4 = queryElementSpecification('dummy4' as TElementName)!;
+            const elementEntry1 = queryElementSpecification('dummy1')!;
+            const elementEntry2 = queryElementSpecification('dummy2')!;
+            const elementEntry3 = queryElementSpecification('dummy3')!;
+            const elementEntry4 = queryElementSpecification('dummy4')!;
 
             expect(elementEntry1.label).toBe('dummy1');
             expect(elementEntry1.type).toBe('Data');
             expect(elementEntry1.category).toBe('dummy');
             expect(
-                (
-                    elementEntry1.prototype as (
-                        name: TElementNameData,
-                        label: string
-                    ) => ElementDataCover
-                )('dummy1' as TElementNameData, 'dummy1') instanceof DummyElementData
+                (elementEntry1.prototype as (name: string, label: string) => ElementDataCover)(
+                    'dummy1',
+                    'dummy1'
+                ) instanceof DummyElementData
             ).toBe(true);
 
             expect(elementEntry2.label).toBe('dummy2');
@@ -245,34 +234,30 @@ describe('Syntax Element Specification', () => {
             expect(
                 (
                     elementEntry2.prototype as (
-                        name: TElementNameExpression,
+                        name: string,
                         label: string
                     ) => ElementExpressionCover
-                )('dummy2' as TElementNameExpression, 'dummy2') instanceof DummyElementExpression
+                )('dummy2', 'dummy2') instanceof DummyElementExpression
             ).toBe(true);
 
             expect(elementEntry3.label).toBe('dummy3');
             expect(elementEntry3.type).toBe('Statement');
             expect(elementEntry3.category).toBe('dummy');
             expect(
-                (
-                    elementEntry3.prototype as (
-                        name: TElementNameStatement,
-                        label: string
-                    ) => ElementStatement
-                )('dummy3' as TElementNameStatement, 'dummy3') instanceof DummyElementStatement
+                (elementEntry3.prototype as (name: string, label: string) => ElementStatement)(
+                    'dummy3',
+                    'dummy3'
+                ) instanceof DummyElementStatement
             ).toBe(true);
 
             expect(elementEntry4.label).toBe('dummy4');
             expect(elementEntry4.type).toBe('Block');
             expect(elementEntry4.category).toBe('dummy');
             expect(
-                (
-                    elementEntry4.prototype as (
-                        name: TElementNameBlock,
-                        label: string
-                    ) => ElementBlock
-                )('dummy4' as TElementNameBlock, 'dummy4') instanceof DummyElementBlock
+                (elementEntry4.prototype as (name: string, label: string) => ElementBlock)(
+                    'dummy4',
+                    'dummy4'
+                ) instanceof DummyElementBlock
             ).toBe(true);
         });
 
@@ -307,16 +292,16 @@ describe('Syntax Element Specification', () => {
         });
 
         test('remove valid element specification entry and verify', () => {
-            const removeStatus = removeElementSpecificationEntry('dummy0' as TElementName);
-            const elementEntry = queryElementSpecification('dummy0' as TElementName)!;
+            const removeStatus = removeElementSpecificationEntry('dummy0');
+            const elementEntry = queryElementSpecification('dummy0')!;
 
             expect(removeStatus).toBe(true);
             expect(elementEntry).toBe(null);
         });
 
         test('remove invalid element specification entry and verify', () => {
-            const removeStatus = removeElementSpecificationEntry('dummy0' as TElementName);
-            const elementEntry = queryElementSpecification('dummy0' as TElementName)!;
+            const removeStatus = removeElementSpecificationEntry('dummy0');
+            const elementEntry = queryElementSpecification('dummy0')!;
 
             expect(removeStatus).toBe(false);
             expect(elementEntry).toBe(null);
@@ -324,36 +309,36 @@ describe('Syntax Element Specification', () => {
 
         test('remove valid element specification entries and verify', () => {
             const removeStatus = removeElementSpecificationEntries([
-                'dummy1' as TElementName,
-                'dummy2' as TElementName,
-                'dummy3' as TElementName,
-                'dummy4' as TElementName,
+                'dummy1',
+                'dummy2',
+                'dummy3',
+                'dummy4',
             ]);
             expect(removeStatus).toEqual([true, true, true, true]);
-            expect(queryElementSpecification('dummy1' as TElementName)!).toBe(null);
-            expect(queryElementSpecification('dummy2' as TElementName)!).toBe(null);
-            expect(queryElementSpecification('dummy3' as TElementName)!).toBe(null);
-            expect(queryElementSpecification('dummy4' as TElementName)!).toBe(null);
+            expect(queryElementSpecification('dummy1')!).toBe(null);
+            expect(queryElementSpecification('dummy2')!).toBe(null);
+            expect(queryElementSpecification('dummy3')!).toBe(null);
+            expect(queryElementSpecification('dummy4')!).toBe(null);
         });
 
         test('remove invalid element specification entries and verify', () => {
             const removeStatus = removeElementSpecificationEntries([
-                'dummy1' as TElementName,
-                'dummy2' as TElementName,
-                'dummy3' as TElementName,
-                'dummy4' as TElementName,
+                'dummy1',
+                'dummy2',
+                'dummy3',
+                'dummy4',
             ]);
             expect(removeStatus).toEqual([false, false, false, false]);
-            expect(queryElementSpecification('dummy1' as TElementName)!).toBe(null);
-            expect(queryElementSpecification('dummy2' as TElementName)!).toBe(null);
-            expect(queryElementSpecification('dummy3' as TElementName)!).toBe(null);
-            expect(queryElementSpecification('dummy4' as TElementName)!).toBe(null);
+            expect(queryElementSpecification('dummy1')!).toBe(null);
+            expect(queryElementSpecification('dummy2')!).toBe(null);
+            expect(queryElementSpecification('dummy3')!).toBe(null);
+            expect(queryElementSpecification('dummy4')!).toBe(null);
         });
 
         test('reset element specification table and verify', () => {
             resetElementSpecificationTable();
-            expect(queryElementSpecification('dummy3' as TElementName)!).toBe(null);
-            expect(queryElementSpecification('dummy4' as TElementName)!).toBe(null);
+            expect(queryElementSpecification('dummy3')!).toBe(null);
+            expect(queryElementSpecification('dummy4')!).toBe(null);
         });
     });
 });

--- a/src/syntax/specification/specification.ts
+++ b/src/syntax/specification/specification.ts
@@ -4,7 +4,6 @@ import {
     IElementSpecificationStatement,
     IElementSpecificationBlock,
     IElementSpecification,
-    TElementName,
 } from '../../@types/specification';
 
 // -- private variables ----------------------------------------------------------------------------
@@ -120,7 +119,7 @@ export function queryElementSpecification(
  * @returns a list of syntax element names.
  */
 export function getElementNames(): string[] {
-    return Object.keys(_elementSpecification) as TElementName[];
+    return Object.keys(_elementSpecification);
 }
 
 /**

--- a/src/syntax/tree/node.ts
+++ b/src/syntax/tree/node.ts
@@ -11,13 +11,6 @@ import {
     ITreeSnapshotExpression,
     ITreeSnapshotStatement,
 } from '../../@types/syntaxTree';
-import {
-    TElementName,
-    TElementNameBlock,
-    TElementNameData,
-    TElementNameExpression,
-    TElementNameStatement,
-} from '../../@types/specification';
 
 import { getInstance } from '../warehouse/warehouse';
 
@@ -30,7 +23,7 @@ import { getInstance } from '../warehouse/warehouse';
  */
 export abstract class TreeNode implements ITreeNode {
     /** Stores the name of the syntax element. */
-    protected _elementName: TElementName;
+    protected _elementName: string;
     /** Stores the node ID of the syntax tree node instance. */
     protected _nodeID: string;
     /** Stores the warehouse ID of the syntax element instance. */
@@ -41,7 +34,7 @@ export abstract class TreeNode implements ITreeNode {
 
     constructor(
         /** Name of the syntax element. */
-        elementName: TElementName,
+        elementName: string,
         /** Node ID of the syntax tree node instance. */
         nodeID: string,
         /** Warehouse ID of the syntax element instance. */
@@ -55,7 +48,7 @@ export abstract class TreeNode implements ITreeNode {
         instance.instance.argLabels.forEach((label) => (this._argConnections[label] = null));
     }
 
-    public abstract get elementName(): TElementName;
+    public abstract get elementName(): string;
 
     public get nodeID(): string {
         return this._nodeID;
@@ -125,13 +118,13 @@ abstract class TreeNodeArgument extends TreeNode implements ITreeNodeArgument {
  * Defines a syntax tree data element node.
  */
 export class TreeNodeData extends TreeNodeArgument implements ITreeNodeData {
-    public get elementName(): TElementNameData {
-        return this._elementName as TElementNameData;
+    public get elementName(): string {
+        return this._elementName;
     }
 
     public get snapshot(): ITreeSnapshotData {
         return {
-            elementName: this._elementName as TElementNameData,
+            elementName: this._elementName,
             nodeID: this._nodeID,
         };
     }
@@ -142,13 +135,13 @@ export class TreeNodeData extends TreeNodeArgument implements ITreeNodeData {
  * Defines a syntax tree expression element node.
  */
 export class TreeNodeExpression extends TreeNodeArgument implements ITreeNodeExpression {
-    public get elementName(): TElementNameExpression {
-        return this._elementName as TElementNameExpression;
+    public get elementName(): string {
+        return this._elementName;
     }
 
     public get snapshot(): ITreeSnapshotExpression {
         return {
-            elementName: this._elementName as TElementNameExpression,
+            elementName: this._elementName,
             nodeID: this._nodeID,
             argMap: this._getArgSnapshot(),
         };
@@ -181,13 +174,13 @@ abstract class TreeNodeInstruction extends TreeNode implements ITreeNodeInstruct
  * Defines a syntax tree statement element node.
  */
 export class TreeNodeStatement extends TreeNodeInstruction implements ITreeNodeStatement {
-    public get elementName(): TElementNameStatement {
-        return this._elementName as TElementNameStatement;
+    public get elementName(): string {
+        return this._elementName;
     }
 
     public get snapshot(): ITreeSnapshotStatement {
         return {
-            elementName: this._elementName as TElementNameStatement,
+            elementName: this._elementName,
             nodeID: this._nodeID,
             argMap: this._getArgSnapshot(),
         };
@@ -199,8 +192,8 @@ export class TreeNodeStatement extends TreeNodeInstruction implements ITreeNodeS
  * Defines a syntax tree block element node.
  */
 export class TreeNodeBlock extends TreeNodeInstruction implements ITreeNodeBlock {
-    public get elementName(): TElementNameBlock {
-        return this._elementName as TElementNameBlock;
+    public get elementName(): string {
+        return this._elementName;
     }
 
     public get snapshot(): ITreeSnapshotBlock {
@@ -213,7 +206,7 @@ export class TreeNodeBlock extends TreeNodeInstruction implements ITreeNodeBlock
         }
 
         return {
-            elementName: this._elementName as TElementNameBlock,
+            elementName: this._elementName,
             nodeID: this._nodeID,
             argMap: this._getArgSnapshot(),
             scope,

--- a/src/syntax/tree/syntaxTree.ts
+++ b/src/syntax/tree/syntaxTree.ts
@@ -1,13 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import {
-    IElementSpecificationInstruction,
-    TElementName,
-    TElementNameData,
-    TElementNameExpression,
-    TElementNameStatement,
-    TElementNameBlock,
-} from '../../@types/specification';
+import { IElementSpecificationInstruction } from '../../@types/specification';
 
 import {
     TreeNode,
@@ -124,7 +117,7 @@ export function getCrumbs(): TreeNode[] {
  * @param name - name of the syntax element
  * @returns node ID of the syntax tree node
  */
-export function addNode(name: TElementName): string {
+export function addNode(name: string): string {
     const instanceID = addInstance(name);
     let nodeID: string;
     do {
@@ -438,24 +431,16 @@ export function attachInstructionInsideCheck(
 
     if (
         (specificationConnector.forbidNestInside &&
-            specificationConnector.forbidNestInside.includes(
-                nodeConnecting.elementName as TElementNameStatement | TElementNameBlock
-            )) ||
+            specificationConnector.forbidNestInside.includes(nodeConnecting.elementName)) ||
         (specificationConnecting.forbiddenNestInside &&
-            specificationConnecting.forbiddenNestInside.includes(
-                nodeConnector.elementName as TElementNameBlock
-            ))
+            specificationConnecting.forbiddenNestInside.includes(nodeConnector.elementName))
     ) {
         return false;
     }
 
     if (specificationConnector.allowNestInside !== undefined) {
         if (specificationConnector.allowNestInside instanceof Array) {
-            if (
-                !specificationConnector.allowNestInside.includes(
-                    nodeConnecting.elementName as TElementNameStatement | TElementNameBlock
-                )
-            ) {
+            if (!specificationConnector.allowNestInside.includes(nodeConnecting.elementName)) {
                 return false;
             }
         } else {
@@ -467,11 +452,7 @@ export function attachInstructionInsideCheck(
 
     if (specificationConnecting.allowedNestInside !== undefined) {
         if (specificationConnecting.allowedNestInside instanceof Array) {
-            if (
-                !specificationConnecting.allowedNestInside.includes(
-                    nodeConnector.elementName as TElementNameBlock
-                )
-            ) {
+            if (!specificationConnecting.allowedNestInside.includes(nodeConnector.elementName)) {
                 return false;
             }
         } else {
@@ -646,24 +627,24 @@ export function generateFromSnapshot(snapshot: ITreeSnapshotInput): void {
     }
 
     function __generateFromSnapshotData(snapshot: ITreeSnapshotDataInput): string {
-        const nodeID = addNode(snapshot.elementName as TElementNameData);
+        const nodeID = addNode(snapshot.elementName);
         return nodeID;
     }
 
     function __generateFromSnapshotExpression(snapshot: ITreeSnapshotExpressionInput): string {
-        const nodeID = addNode(snapshot.elementName as TElementNameExpression);
+        const nodeID = addNode(snapshot.elementName);
         __generateFromSnapshotArg(nodeID, snapshot.argMap);
         return nodeID;
     }
 
     function __generateFromSnapshotStatement(snapshot: ITreeSnapshotStatementInput): string {
-        const nodeID = addNode(snapshot.elementName as TElementNameStatement);
+        const nodeID = addNode(snapshot.elementName);
         __generateFromSnapshotArg(nodeID, snapshot.argMap);
         return nodeID;
     }
 
     function __generateFromSnapshotBlock(snapshot: ITreeSnapshotBlockInput): string {
-        const nodeID = addNode(snapshot.elementName as TElementNameBlock);
+        const nodeID = addNode(snapshot.elementName);
         __generateFromSnapshotArg(nodeID, snapshot.argMap);
         const innerNodeID = __generateSnapshotList(snapshot.scope);
         if (innerNodeID !== null) {

--- a/src/syntax/warehouse/warehouse.ts
+++ b/src/syntax/warehouse/warehouse.ts
@@ -1,14 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import {
-    TElementName,
-    TElementKind,
-    TElementType,
-    TElementNameData,
-    TElementNameExpression,
-    TElementNameStatement,
-    TElementNameBlock,
-} from '../../@types/specification';
+import { TElementKind, TElementType } from '../../@types/specification';
 import {
     getElementNames,
     getElementCategories,
@@ -42,28 +34,28 @@ let _elementMap: {
         | {
               instance: _ElementDataCover;
               type: 'Data';
-              name: TElementNameData;
+              name: string;
               kind: 'Argument';
               category: string;
           }
         | {
               instance: _ElementExpressionCover;
               type: 'Expression';
-              name: TElementNameExpression;
+              name: string;
               kind: 'Argument';
               category: string;
           }
         | {
               instance: ElementStatement;
               type: 'Statement';
-              name: TElementNameStatement;
+              name: string;
               kind: 'Instruction';
               category: string;
           }
         | {
               instance: ElementBlock;
               type: 'Block';
-              name: TElementNameBlock;
+              name: string;
               kind: 'Instruction';
               category: string;
           };
@@ -80,7 +72,7 @@ let _elementMap: {
  * @param category - category of the element
  */
 function _addInstance(
-    elementName: TElementName,
+    elementName: string,
     instanceID: string,
     instance: ElementSyntax,
     type: TElementType,
@@ -92,7 +84,7 @@ function _addInstance(
         case 'Data':
             _elementMap[instanceID] = {
                 instance: instance as _ElementDataCover,
-                name: elementName as TElementNameData,
+                name: elementName,
                 type: type as 'Data',
                 kind: 'Argument',
                 category: category as string,
@@ -101,7 +93,7 @@ function _addInstance(
         case 'Expression':
             _elementMap[instanceID] = {
                 instance: instance as _ElementExpressionCover,
-                name: elementName as TElementNameExpression,
+                name: elementName,
                 type: type as 'Expression',
                 kind: 'Argument',
                 category: category as string,
@@ -110,7 +102,7 @@ function _addInstance(
         case 'Statement':
             _elementMap[instanceID] = {
                 instance: instance as ElementStatement,
-                name: elementName as TElementNameStatement,
+                name: elementName,
                 type: type as 'Statement',
                 kind: 'Instruction',
                 category: category as string,
@@ -119,7 +111,7 @@ function _addInstance(
         case 'Block':
             _elementMap[instanceID] = {
                 instance: instance as ElementBlock,
-                name: elementName as TElementNameBlock,
+                name: elementName,
                 type: type as 'Block',
                 kind: 'Instruction',
                 category: category as string,
@@ -178,7 +170,7 @@ function _resetElementCategoryCountMap(): void {
  * @param elementName - name of the element
  * @returns - unique instance ID for the element instance
  */
-export function addInstance(elementName: TElementName): string {
+export function addInstance(elementName: string): string {
     const elementSpecification = queryElementSpecification(elementName);
 
     if (elementSpecification === null) {
@@ -191,28 +183,27 @@ export function addInstance(elementName: TElementName): string {
 
     switch (type) {
         case 'Data':
-            instance = (prototype as (name: TElementNameData, label: string) => _ElementDataCover)(
-                elementName as TElementNameData,
+            instance = (prototype as (name: string, label: string) => _ElementDataCover)(
+                elementName,
                 label
             );
             break;
         case 'Expression':
-            instance = (
-                prototype as (
-                    name: TElementNameExpression,
-                    label: string
-                ) => _ElementExpressionCover
-            )(elementName as TElementNameExpression, label);
+            instance = (prototype as (name: string, label: string) => _ElementExpressionCover)(
+                elementName,
+                label
+            );
             break;
         case 'Statement':
-            instance = (
-                prototype as (name: TElementNameStatement, label: string) => ElementStatement
-            )(elementName as TElementNameStatement, label);
+            instance = (prototype as (name: string, label: string) => ElementStatement)(
+                elementName,
+                label
+            );
             break;
         case 'Block':
         default:
-            instance = (prototype as (name: TElementNameBlock, label: string) => ElementBlock)(
-                elementName as TElementNameBlock,
+            instance = (prototype as (name: string, label: string) => ElementBlock)(
+                elementName,
                 label
             );
     }
@@ -233,7 +224,7 @@ export function addInstance(elementName: TElementName): string {
  * @returns element instance with additional properties
  */
 export function getInstance(instanceID: string): {
-    name: TElementName;
+    name: string;
     kind: TElementKind;
     type: TElementType;
     category: string;
@@ -264,7 +255,7 @@ export function removeInstance(instanceID: string): void {
  * @param name - name of the element
  * @returns count of the element instances for the element name
  */
-export function getNameCount(name: TElementName): number {
+export function getNameCount(name: string): number {
     return _elementNameCountMap[name];
 }
 


### PR DESCRIPTION
replace type from `TElementName`, `TElementNameData`, `TElementNameExpression`, `TElementNameStatement`, `TElementNameBlock` to `string` for element name