### PR TITLE
Syntax tree: Provide initialisation values in snapshot of data elements

### DIFF
--- a/src/@types/specification.d.ts
+++ b/src/@types/specification.d.ts
@@ -1,4 +1,4 @@
-import { TData } from './data';
+import { TData, TDataName } from './data';
 import {
     IElementData,
     IElementExpression,
@@ -20,6 +20,11 @@ export interface IElementSpecificationData {
     type: 'Data';
     category: string;
     prototype: (name: string, label: string) => IElementData<TData>;
+    values?:
+        | string[]
+        | {
+              types: TDataName[];
+          };
 }
 
 /** Type for the specification entry object for data elements. */
@@ -108,6 +113,11 @@ export interface IElementSpecification {
     forbiddenNestInside?: string[];
     allowNestInside?: string[] | boolean;
     forbidNestInside?: string[] | boolean;
+    values?:
+        | string[]
+        | {
+              types: TDataName[];
+          };
 }
 
 /** Type for the snapshot of an element's specification. */

--- a/src/@types/syntaxTree.d.ts
+++ b/src/@types/syntaxTree.d.ts
@@ -4,6 +4,8 @@
 export interface ITreeSnapshotDataInput {
     /** Name of the data element. */
     elementName: string;
+    /** Value to initialize data element with. */
+    value?: string;
 }
 
 /** Type definition for the snapshot of a data element. */

--- a/src/execution/interpreter.spec.ts
+++ b/src/execution/interpreter.spec.ts
@@ -1,10 +1,9 @@
 import { run } from './interpreter';
 
-import { generateFromSnapshot, generateSnapshot, getNode } from '../syntax/tree/syntaxTree';
+import { generateFromSnapshot, generateSnapshot } from '../syntax/tree/syntaxTree';
 
 import { registerElementSpecificationEntries } from '../syntax/specification/specification';
 import elementSpecification from '../library/specification';
-import { getInstance } from '../syntax/warehouse/warehouse';
 
 // -------------------------------------------------------------------------------------------------
 
@@ -37,9 +36,11 @@ describe('Interpreter', () => {
                             argMap: {
                                 name: {
                                     elementName: 'value-string',
+                                    value: 'a',
                                 },
                                 value: {
                                     elementName: 'value-number',
+                                    value: '0',
                                 },
                             },
                         },
@@ -48,9 +49,11 @@ describe('Interpreter', () => {
                             argMap: {
                                 name: {
                                     elementName: 'value-string',
+                                    value: 'b',
                                 },
                                 value: {
                                     elementName: 'value-number',
+                                    value: '1',
                                 },
                             },
                         },
@@ -59,9 +62,11 @@ describe('Interpreter', () => {
                             argMap: {
                                 name: {
                                     elementName: 'value-string',
+                                    value: 'c',
                                 },
                                 value: {
                                     elementName: 'value-number',
+                                    value: '1',
                                 },
                             },
                         },
@@ -70,6 +75,7 @@ describe('Interpreter', () => {
                             argMap: {
                                 times: {
                                     elementName: 'value-number',
+                                    value: '10',
                                 },
                             },
                             scope: [
@@ -78,6 +84,7 @@ describe('Interpreter', () => {
                                     argMap: {
                                         value: {
                                             elementName: 'boxidentifier-number',
+                                            value: 'c',
                                         },
                                     },
                                 },
@@ -86,15 +93,18 @@ describe('Interpreter', () => {
                                     argMap: {
                                         name: {
                                             elementName: 'value-string',
+                                            value: 'c',
                                         },
                                         value: {
                                             elementName: 'operator-math-plus',
                                             argMap: {
                                                 operand1: {
                                                     elementName: 'boxidentifier-number',
+                                                    value: 'a',
                                                 },
                                                 operand2: {
                                                     elementName: 'boxidentifier-number',
+                                                    value: 'b',
                                                 },
                                             },
                                         },
@@ -105,9 +115,11 @@ describe('Interpreter', () => {
                                     argMap: {
                                         name: {
                                             elementName: 'value-string',
+                                            value: 'a',
                                         },
                                         value: {
                                             elementName: 'boxidentifier-number',
+                                            value: 'b',
                                         },
                                     },
                                 },
@@ -116,9 +128,11 @@ describe('Interpreter', () => {
                                     argMap: {
                                         name: {
                                             elementName: 'value-string',
+                                            value: 'b',
                                         },
                                         value: {
                                             elementName: 'boxidentifier-number',
+                                            value: 'c',
                                         },
                                     },
                                 },
@@ -131,75 +145,6 @@ describe('Interpreter', () => {
             crumbs: [],
         });
         const snapshot = generateSnapshot();
-
-        getInstance(
-            // @ts-ignore
-            getNode(snapshot.process[0].scope[0].argMap['name']['nodeID'])!.instanceID
-        )!.instance.updateLabel('a');
-        getInstance(
-            // @ts-ignore
-            getNode(snapshot.process[0].scope[0].argMap['value']['nodeID'])!.instanceID
-        )!.instance.updateLabel('0');
-        getInstance(
-            // @ts-ignore
-            getNode(snapshot.process[0].scope[1].argMap['name']['nodeID'])!.instanceID
-        )!.instance.updateLabel('b');
-        getInstance(
-            // @ts-ignore
-            getNode(snapshot.process[0].scope[1].argMap['value']['nodeID'])!.instanceID
-        )!.instance.updateLabel('1');
-        getInstance(
-            // @ts-ignore
-            getNode(snapshot.process[0].scope[2].argMap['name']['nodeID'])!.instanceID
-        )!.instance.updateLabel('c');
-        getInstance(
-            // @ts-ignore
-            getNode(snapshot.process[0].scope[2].argMap['value']['nodeID'])!.instanceID
-        )!.instance.updateLabel('1');
-        getInstance(
-            // @ts-ignore
-            getNode(snapshot.process[0].scope[3].argMap['times']['nodeID'])!.instanceID
-        )!.instance.updateLabel('10');
-        getInstance(
-            // @ts-ignore
-            getNode(snapshot.process[0].scope[3].scope[0].argMap['value']['nodeID'])!.instanceID
-        )!.instance.updateLabel('c');
-        getInstance(
-            // @ts-ignore
-            getNode(snapshot.process[0].scope[3].scope[1].argMap['name']['nodeID'])!.instanceID
-        )!.instance.updateLabel('c');
-        getInstance(
-            getNode(
-                // @ts-ignore
-                snapshot.process[0].scope[3].scope[1].argMap['value']['argMap']['operand1'][
-                    'nodeID'
-                ]
-            )!.instanceID
-        )!.instance.updateLabel('a');
-        getInstance(
-            getNode(
-                // @ts-ignore
-                snapshot.process[0].scope[3].scope[1].argMap['value']['argMap']['operand2'][
-                    'nodeID'
-                ]
-            )!.instanceID
-        )!.instance.updateLabel('b');
-        getInstance(
-            // @ts-ignore
-            getNode(snapshot.process[0].scope[3].scope[2].argMap['name']['nodeID'])!.instanceID
-        )!.instance.updateLabel('a');
-        getInstance(
-            // @ts-ignore
-            getNode(snapshot.process[0].scope[3].scope[2].argMap['value']['nodeID'])!.instanceID
-        )!.instance.updateLabel('b');
-        getInstance(
-            // @ts-ignore
-            getNode(snapshot.process[0].scope[3].scope[3].argMap['name']['nodeID'])!.instanceID
-        )!.instance.updateLabel('b');
-        getInstance(
-            // @ts-ignore
-            getNode(snapshot.process[0].scope[3].scope[3].argMap['value']['nodeID'])!.instanceID
-        )!.instance.updateLabel('c');
 
         const node = snapshot.process[0];
         run(node.nodeID);

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ export {
     getElementCategories,
     resetElementSpecificationTable,
     getSpecificationSnapshot,
+    checkValueAssignment,
 } from './syntax/specification/specification';
 
 // -- syntax tree ----------------------------------------------------------------------------------

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export {
     generateSnapshot,
     generateFromSnapshot,
     resetSyntaxTree,
+    assignNodeValue,
 } from './syntax/tree/syntaxTree';
 
 // -- warehouse ------------------------------------------------------------------------------------

--- a/src/library/specification.ts
+++ b/src/library/specification.ts
@@ -50,12 +50,18 @@ const _elementSpecificationEntries: {
         type: 'Data',
         category: 'value',
         prototype: ElementValueBoolean,
+        values: {
+            types: ['boolean'],
+        },
     },
     'value-number': {
         label: '0',
         type: 'Data',
         category: 'value',
         prototype: ElementValueNumber,
+        values: {
+            types: ['number'],
+        },
     },
     'value-string': {
         label: 'string',

--- a/src/syntax/specification/specification.spec.ts
+++ b/src/syntax/specification/specification.spec.ts
@@ -6,6 +6,7 @@ import {
     removeElementSpecificationEntries,
     resetElementSpecificationTable,
     getSpecificationSnapshot,
+    checkValueAssignment,
 } from './specification';
 
 import elementSpecificationEntries from '../../library/specification';
@@ -385,14 +386,103 @@ describe('Syntax Element Specification', () => {
             resetElementSpecificationTable();
             expect(getSpecificationSnapshot()).toEqual({});
 
-            registerElementSpecificationEntry('mydummy', {
-                label: 'dummy',
-                type: 'Data',
-                category: 'dummy',
-                prototype: DummyElementData,
-                values: ['1', '2', '3'],
+            registerElementSpecificationEntries({
+                dummy: {
+                    label: 'dummy',
+                    type: 'Data',
+                    category: 'dummy',
+                    prototype: DummyElementData,
+                    values: ['1', '2', '3'],
+                },
             });
-            expect(getSpecificationSnapshot()['mydummy'].values).toEqual(['1', '2', '3']);
+            expect(getSpecificationSnapshot()['dummy'].values).toEqual(['1', '2', '3']);
+        });
+
+        test('check against specification valid value assignment', () => {
+            resetElementSpecificationTable();
+            registerElementSpecificationEntries({
+                dummy1: {
+                    label: 'dummy1',
+                    type: 'Data',
+                    category: 'dummy',
+                    prototype: DummyElementData,
+                },
+                dummy2: {
+                    label: 'dummy2',
+                    type: 'Data',
+                    category: 'dummy',
+                    prototype: DummyElementData,
+                    values: ['1', '2', '3'],
+                },
+                dummy3: {
+                    label: 'dummy3',
+                    type: 'Data',
+                    category: 'dummy',
+                    prototype: DummyElementData,
+                    values: { types: ['boolean'] },
+                },
+                dummy4: {
+                    label: 'dummy4',
+                    type: 'Data',
+                    category: 'dummy',
+                    prototype: DummyElementData,
+                    values: { types: ['number'] },
+                },
+                dummy5: {
+                    label: 'dummy5',
+                    type: 'Data',
+                    category: 'dummy',
+                    prototype: DummyElementData,
+                    values: { types: ['string'] },
+                },
+            });
+
+            expect(checkValueAssignment('dummy1', 'foobar')).toBe(true);
+            expect(checkValueAssignment('dummy2', '2')).toBe(true);
+            expect(checkValueAssignment('dummy3', 'true')).toBe(true);
+            expect(checkValueAssignment('dummy4', '55')).toBe(true);
+            expect(checkValueAssignment('dummy5', 'true')).toBe(true);
+            expect(checkValueAssignment('dummy5', '55')).toBe(true);
+            expect(checkValueAssignment('dummy5', 'foobar')).toBe(true);
+        });
+
+        test('check against specification invalid value assignment', () => {
+            resetElementSpecificationTable();
+            registerElementSpecificationEntries({
+                dummy1: {
+                    label: 'dummy1',
+                    type: 'Data',
+                    category: 'dummy',
+                    prototype: DummyElementData,
+                    values: ['1', '2', '3'],
+                },
+                dummy2: {
+                    label: 'dummy2',
+                    type: 'Data',
+                    category: 'dummy',
+                    prototype: DummyElementData,
+                    values: { types: ['boolean'] },
+                },
+                dummy3: {
+                    label: 'dummy3',
+                    type: 'Data',
+                    category: 'dummy',
+                    prototype: DummyElementData,
+                    values: { types: ['boolean'] },
+                },
+                dummy4: {
+                    label: 'dummy4',
+                    type: 'Data',
+                    category: 'dummy',
+                    prototype: DummyElementData,
+                    values: { types: ['number'] },
+                },
+            });
+
+            expect(checkValueAssignment('dummy1', '4')).toBe(false);
+            expect(checkValueAssignment('dummy2', '5')).toBe(false);
+            expect(checkValueAssignment('dummy3', '5')).toBe(false);
+            expect(checkValueAssignment('dummy4', 'true')).toBe(false);
         });
     });
 });

--- a/src/syntax/specification/specification.spec.ts
+++ b/src/syntax/specification/specification.spec.ts
@@ -10,6 +10,7 @@ import {
 
 import elementSpecificationEntries from '../../library/specification';
 
+import { IElementSpecificationData } from '../../@types/specification';
 import { TData } from '../../@types/data';
 import { ElementData, ElementExpression } from '../elements/elementArgument';
 import { ElementStatement, ElementBlock } from '../elements/elementInstruction';
@@ -157,22 +158,27 @@ describe('Syntax Element Specification', () => {
         test('register new element specification entry and verify', () => {
             const status = registerElementSpecificationEntry('dummy0', {
                 label: 'dummy0',
-                type: 'Block',
+                type: 'Data',
                 category: 'dummy',
-                prototype: DummyElementBlock,
+                prototype: DummyElementData,
+                values: { types: ['boolean'] },
             });
             expect(status).toBe(true);
 
             const elementEntry = queryElementSpecification('dummy0')!;
             expect(elementEntry.label).toBe('dummy0');
-            expect(elementEntry.type).toBe('Block');
+            expect(elementEntry.type).toBe('Data');
             expect(elementEntry.category).toBe('dummy');
             expect(
-                (elementEntry.prototype as (name: string, label: string) => ElementBlock)(
+                (elementEntry.prototype as (name: string, label: string) => ElementDataCover)(
                     'dummy0',
                     'dummy0'
-                ) instanceof DummyElementBlock
+                ) instanceof DummyElementData
             ).toBe(true);
+            expect('values' in elementEntry).toBe(true);
+            expect((elementEntry as IElementSpecificationData).values).toEqual({
+                types: ['boolean'],
+            });
         });
 
         test('register duplicate element specification entry and verify', () => {
@@ -192,6 +198,7 @@ describe('Syntax Element Specification', () => {
                     type: 'Data',
                     category: 'dummy',
                     prototype: DummyElementData,
+                    values: ['1', '2', '3'],
                 },
                 dummy2: {
                     label: 'dummy2',
@@ -228,6 +235,8 @@ describe('Syntax Element Specification', () => {
                     'dummy1'
                 ) instanceof DummyElementData
             ).toBe(true);
+            expect('values' in elementEntry1).toBe(true);
+            expect((elementEntry1 as IElementSpecificationData).values).toEqual(['1', '2', '3']);
 
             expect(elementEntry2.label).toBe('dummy2');
             expect(elementEntry2.type).toBe('Expression');
@@ -375,6 +384,15 @@ describe('Syntax Element Specification', () => {
 
             resetElementSpecificationTable();
             expect(getSpecificationSnapshot()).toEqual({});
+
+            registerElementSpecificationEntry('mydummy', {
+                label: 'dummy',
+                type: 'Data',
+                category: 'dummy',
+                prototype: DummyElementData,
+                values: ['1', '2', '3'],
+            });
+            expect(getSpecificationSnapshot()['mydummy'].values).toEqual(['1', '2', '3']);
         });
     });
 });

--- a/src/syntax/specification/specification.ts
+++ b/src/syntax/specification/specification.ts
@@ -61,6 +61,8 @@ export function registerElementSpecificationEntry(
         if (!['label', 'type', 'category', 'prototype'].includes(key)) {
             // @ts-ignore
             specificationTableEntry[key] = value;
+            // @ts-ignore
+            specificationSnapshotTableEntry[key] = value;
         }
     });
 

--- a/src/syntax/specification/specification.ts
+++ b/src/syntax/specification/specification.ts
@@ -1,3 +1,4 @@
+import { TDataName } from 'index';
 import {
     IElementSpecificationData,
     IElementSpecificationExpression,
@@ -168,6 +169,36 @@ export function getSpecificationSnapshot(): {
     [name: string]: IElementSpecificationSnapshot;
 } {
     return _elementSpecificationSnapshot;
+}
+
+/**
+ * Check if `value` can be assigned to element `name`.
+ * @param name name of the syntax element (expecting a data element)
+ * @param value value to check
+ * @returns whether value can be assigned
+ */
+export function checkValueAssignment(name: string, value: string): boolean {
+    if ('values' in _elementSpecification[name]) {
+        const values = (_elementSpecification[name] as IElementSpecificationData).values!;
+
+        if (values instanceof Array) {
+            return values.includes(value);
+        } else {
+            let typeDeepInfer: TDataName;
+            if (['true', 'false'].includes(value)) {
+                typeDeepInfer = 'boolean';
+            } else if (!isNaN(Number(value))) {
+                typeDeepInfer = 'number';
+            } else {
+                typeDeepInfer = 'string';
+            }
+
+            return (
+                values.types.includes(typeDeepInfer as TDataName) || values.types.includes('string')
+            );
+        }
+    }
+    return true;
 }
 
 resetElementSpecificationTable();

--- a/src/syntax/tree/syntaxTree.spec.ts
+++ b/src/syntax/tree/syntaxTree.spec.ts
@@ -14,6 +14,7 @@ import {
     generateSnapshot,
     generateFromSnapshot,
     resetSyntaxTree,
+    assignNodeValue,
 } from './syntaxTree';
 import { getInstance } from '../warehouse/warehouse';
 
@@ -466,6 +467,64 @@ describe('Syntax Tree', () => {
             }).toThrowError(
                 'InvalidDataError: value "foobar" cannot be assigned to data element "value-number"'
             );
+        });
+    });
+
+    describe('value assignment to node', () => {
+        test('validate invalid attempt to assign value to non-data element', () => {
+            generateFromSnapshot({
+                process: [],
+                routine: [],
+                crumbs: [
+                    [
+                        {
+                            elementName: 'operator-math-plus',
+                            argMap: {
+                                operand1: null,
+                                operand2: null,
+                            },
+                        },
+                    ],
+                ],
+            });
+            const snapshot = generateSnapshot();
+            expect(assignNodeValue(snapshot.crumbs[0][0].nodeID, 'foobar')).toBe(false);
+        });
+
+        test('validate invalid attempt to assign value to non-existing element', () => {
+            expect(assignNodeValue('123456', 'foobar')).toBe(false);
+        });
+
+        test('validate valid attempt to assign invalid value to data element', () => {
+            generateFromSnapshot({
+                process: [],
+                routine: [],
+                crumbs: [
+                    [
+                        {
+                            elementName: 'value-number',
+                        },
+                    ],
+                ],
+            });
+            const snapshot = generateSnapshot();
+            expect(assignNodeValue(snapshot.crumbs[0][0].nodeID, 'foobar')).toBe(false);
+        });
+
+        test('validate valid attempt to assign valid value to data element', () => {
+            generateFromSnapshot({
+                process: [],
+                routine: [],
+                crumbs: [
+                    [
+                        {
+                            elementName: 'value-boolean',
+                        },
+                    ],
+                ],
+            });
+            const snapshot = generateSnapshot();
+            expect(assignNodeValue(snapshot.crumbs[0][0].nodeID, 'true')).toBe(true);
         });
     });
 });

--- a/src/syntax/tree/syntaxTree.spec.ts
+++ b/src/syntax/tree/syntaxTree.spec.ts
@@ -412,7 +412,7 @@ describe('Syntax Tree', () => {
             }
         });
 
-        test('validate tree generation with initialisation values', () => {
+        test('validate tree generation with valid initialisation values', () => {
             const snapshotInput: ITreeSnapshotInput = {
                 process: [],
                 routine: [],
@@ -440,6 +440,32 @@ describe('Syntax Tree', () => {
                     getNode(snapshotOutput.crumbs[0][0].argMap['operand2'].nodeID)!.instanceID
                 )!.instance.label
             ).toBe('5');
+        });
+
+        test('validate tree generation with invalid initialisation values', () => {
+            const snapshotInput: ITreeSnapshotInput = {
+                process: [],
+                routine: [],
+                crumbs: [
+                    [
+                        {
+                            elementName: 'operator-math-plus',
+                            argMap: {
+                                operand1: null,
+                                operand2: {
+                                    elementName: 'value-number',
+                                    value: 'foobar',
+                                },
+                            },
+                        },
+                    ],
+                ],
+            };
+            expect(() => {
+                generateFromSnapshot(snapshotInput);
+            }).toThrowError(
+                'InvalidDataError: value "foobar" cannot be assigned to data element "value-number"'
+            );
         });
     });
 });

--- a/src/syntax/tree/syntaxTree.spec.ts
+++ b/src/syntax/tree/syntaxTree.spec.ts
@@ -247,7 +247,7 @@ describe('Syntax Tree', () => {
     });
 
     describe('tree generation from snapshot', () => {
-        test('validate tree generation', () => {
+        test('validate tree generation without initialisation values', () => {
             const snapshotInput: ITreeSnapshotInput = {
                 process: [
                     {
@@ -410,6 +410,36 @@ describe('Syntax Tree', () => {
                     __check(snapshotInput.crumbs[i][j], snapshotOutput.crumbs[i][j]);
                 }
             }
+        });
+
+        test('validate tree generation with initialisation values', () => {
+            const snapshotInput: ITreeSnapshotInput = {
+                process: [],
+                routine: [],
+                crumbs: [
+                    [
+                        {
+                            elementName: 'operator-math-plus',
+                            argMap: {
+                                operand1: null,
+                                operand2: {
+                                    elementName: 'value-number',
+                                    value: '5',
+                                },
+                            },
+                        },
+                    ],
+                ],
+            };
+            generateFromSnapshot(snapshotInput);
+            const snapshotOutput = generateSnapshot();
+
+            expect(
+                getInstance(
+                    // @ts-ignore
+                    getNode(snapshotOutput.crumbs[0][0].argMap['operand2'].nodeID)!.instanceID
+                )!.instance.label
+            ).toBe('5');
         });
     });
 });

--- a/src/syntax/tree/syntaxTree.ts
+++ b/src/syntax/tree/syntaxTree.ts
@@ -628,6 +628,9 @@ export function generateFromSnapshot(snapshot: ITreeSnapshotInput): void {
 
     function __generateFromSnapshotData(snapshot: ITreeSnapshotDataInput): string {
         const nodeID = addNode(snapshot.elementName);
+        if (snapshot.value) {
+            getInstance(getNode(nodeID)!.instanceID)!.instance.updateLabel(snapshot.value);
+        }
         return nodeID;
     }
 

--- a/src/syntax/tree/syntaxTree.ts
+++ b/src/syntax/tree/syntaxTree.ts
@@ -673,3 +673,24 @@ export function generateFromSnapshot(snapshot: ITreeSnapshotInput): void {
         throw e;
     }
 }
+
+/**
+ * Assigns the value (label) of the data element instance included in the node `nodeID`.
+ * @param nodeID node ID of the syntax tree node
+ * @param value value to assign
+ * @returns whether successful assignment or not
+ */
+export function assignNodeValue(nodeID: string, value: string): boolean {
+    try {
+        const instance = getInstance(getNode(nodeID)!.instanceID)!.instance;
+        if (instance.type === 'Data' && checkValueAssignment(instance.name, value)) {
+            instance.updateLabel(value);
+        } else {
+            throw Error();
+        }
+    } catch (e) {
+        return false;
+    }
+
+    return true;
+}


### PR DESCRIPTION
- Adds provision to provide initialisation value in the snapshots of data elements. Provided value is updated in the syntax tree node's element instance after syntax tree node is added.
- Adds provision to provide accepted values constraint in specification.
- Adds value assignment check functions.
- Performs checks before assigning values from snapshot.
- Adds a function to directly assign value to syntax tree node's data element instance.