### PR TITLE
Fix: Testing Coverage Path in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /node_modules
 
 # testing
-/coverage
+/src/coverage
 
 # production
 /build


### PR DESCRIPTION
Path for `yarn test --coverage` is `/src/coverage` not `/coverage`