### PR TITLE
Fixed typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ spawned and standard input/output is connected to the terminal.
 
     ```bash
     v14.16.1
-    7.9.0
+    1.22.19
     Version 4.2.4
     v9.1.1
     ```

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Output should look like
 
 ```bash
 v14.17.0
-6.14.13
+1.22.19
 Version 4.3.2
 v10.0.0
 ```


### PR DESCRIPTION
`node -v && yarn -v && tsc -v && ts-node -v`
 Output :

```bash
v14.17.0
6.14.13
Version 4.3.2
v10.0.0
```
Expected Output :

```bash
v14.17.0
1.22.19 -latest
Version 4.3.2
v10.0.0
```

@meganindya The npm version is specified instead of yarn v, please have a look